### PR TITLE
Update version to 3.2.0

### DIFF
--- a/integration/typeorm/package-lock.json
+++ b/integration/typeorm/package-lock.json
@@ -71,9 +71,9 @@
       }
     },
     "@nestjsx/crud": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@nestjsx/crud/-/crud-3.0.0-rc.2.tgz",
-      "integrity": "sha512-iB16e0tViXYHPand/WGlJZyN2hk76rl6kNbNEK0AtqNjXWC8rbgYTVLvGeSIgYwIGp46wrBWS1HIwr8ZCe1P/Q=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjsx/crud/-/crud-3.2.0.tgz",
+      "integrity": "sha512-x8pgrp4oA6BHlsRKixr/V38nkKau8F8KzBK9ZovNi4MIECi1qr8dB2vCu75Hat+PzCvJTjAg1QtgFfLL+ePVrA=="
     },
     "@nuxtjs/opencollective": {
       "version": "0.2.1",

--- a/integration/typeorm/package.json
+++ b/integration/typeorm/package.json
@@ -18,7 +18,7 @@
     "@nestjs/swagger": "^3.0.2",
     "@nestjs/testing": "^6.0.2",
     "@nestjs/typeorm": "^6.0.0",
-    "@nestjsx/crud": "^3.0.0-rc.2",
+    "@nestjsx/crud": "^3.2.0",
     "class-transformer": "^0.2.0",
     "class-validator": "^0.9.1",
     "js-yaml": "^3.12.0",


### PR DESCRIPTION
Default installation fails to run npm run serve. Integration has version 3.0.0-rc2 in package-lock.json and package.json. Companies controller uses ParsedParams and UsePathInterceptors which were added later.