### PR TITLE
make buildQuery available when override service methods

### DIFF
--- a/src/typeorm/repository-service.class.ts
+++ b/src/typeorm/repository-service.class.ts
@@ -195,7 +195,7 @@ export class RepositoryService<T> extends RestfulService<T> {
    * @param options
    * @param many
    */
-  private async buildQuery(
+  protected async buildQuery(
     query: RequestParamsParsed,
     options: RestfulOptions = {},
     many = true,


### PR DESCRIPTION
change `buildQuery`'s access modifier to `protected`, so it can be used in derived classes.

recently I often encountered this use case which I need manually add some filters:
```ts
async getMany(query: RequestParamsParsed, options: RestfulOptions) {
    const statusFilter = _.chain(query.filter).remove(o => o.field === 'status').first().value();
    // @ts-ignore
    const builder = await this.buildQuery(query, options);

    if (statusFilter) {
      switch (statusFilter.operator) {
        case 'eq':
          builder.andWhere(...this.statusToWhere(builder.alias, statusFilter.value));
          break;
        case 'in':
          builder.andWhere(..._.chain(statusFilter.value)
            .map(v => this.statusToWhere(builder.alias, v))
            .reduce((acc: [string[], any], v) => {
              acc[0].push(`(${v[0]})`);
              _.assign(acc[1], v[1]);
              return acc;
            }, [[], {}])
            .thru(([a, b]) => [`(${a.join(' OR ')})`, b])
            .value());
          break;
        default:
          throw new BadRequestException('status仅支持eq或者in');
      }
    }

    const mergedOptions = Object.assign({}, this.options, options);
    if (this.decidePagination(query, mergedOptions)) {
      const [data, total] = await builder.getManyAndCount();
      const limit = builder.expressionMap.take;
      const offset = builder.expressionMap.skip;
      return this.createPageInfo(data, total, limit, offset);
    }
    return builder.getMany();
  }
```