### PR TITLE
Set decorators after Swagger so metadata can be overwritten

### DIFF
--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -285,12 +285,13 @@ export class CrudRoutesFactory {
     this.setRouteArgs(name);
     this.setRouteArgsTypes(name);
     this.setInterceptors(name);
-    this.setDecorators(name);
     this.setAction(name);
     this.setSwaggerOperation(name);
     this.setSwaggerPathParams(name);
     this.setSwaggerQueryParams(name);
     this.setSwaggerResponseOk(name);
+    // set decorators after Swagger so metadata can be overwritten
+    this.setDecorators(name);
   }
 
   private setRouteArgs(name: BaseRouteName) {


### PR DESCRIPTION
It's possible to specify decorators for CRUD routes but `@nestjs/swagger` decorators aren't working because metadata is overwritten by `@nestjsx/crud`.

This PR changes the behavior a little bit so default Swagger metadata is set before setting decorators so it's possible to set custom Swagger metadata:

```
import { ApiOperation } from '@nestjs/swagger';

@Crud({
  model: {
    type: Entity,
  },
  routes: {
    getManyBase: {
      decorators: [
        ApiOperation({
          title: 'Get list of entities',
          operationId: 'getEntities',
        }),
      ],
    },
  },
})
```

Custom routes metadata is useful for generating API client from Swagger.

Please let me know if you have any questions.