### PR TITLE
support nested sort

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -617,8 +617,7 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     cond: QueryFilter,
     param: any,
   ): { str: string; params: ObjectLiteral } {
-    const field =
-      cond.field.indexOf('.') === -1 ? `${this.alias}.${cond.field}` : cond.field;
+    const field = this.getFieldWithAlias(cond.field);
     let str: string;
     let params: ObjectLiteral;
 

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -1,23 +1,23 @@
-import { Repository, ObjectLiteral, SelectQueryBuilder, Brackets } from 'typeorm';
-import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
-import { plainToClass } from 'class-transformer';
-import { ClassType } from 'class-transformer/ClassTransformer';
 import {
+  CreateManyDto,
   CrudRequest,
   CrudRequestOptions,
-  CreateManyDto,
-  QueryOptions,
-  JoinOptions,
   GetManyDefaultResponse,
+  JoinOptions,
+  QueryOptions,
 } from '@nestjsx/crud';
-import { CrudService } from '@nestjsx/crud/lib/services';
 import {
-  QueryJoin,
-  QueryFilter,
-  QuerySort,
   ParsedRequestParams,
+  QueryFilter,
+  QueryJoin,
+  QuerySort,
 } from '@nestjsx/crud-request';
-import { isArrayFull, isObject, hasLength, objKeys, isUndefined } from '@nestjsx/util';
+import { CrudService } from '@nestjsx/crud/lib/services';
+import { hasLength, isArrayFull, isObject, isUndefined, objKeys } from '@nestjsx/util';
+import { plainToClass } from 'class-transformer';
+import { ClassType } from 'class-transformer/ClassTransformer';
+import { Brackets, ObjectLiteral, Repository, SelectQueryBuilder } from 'typeorm';
+import { RelationMetadata } from 'typeorm/metadata/RelationMetadata';
 
 export class TypeOrmCrudService<T> extends CrudService<T> {
   private entityColumns: string[];
@@ -270,7 +270,7 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     const allowedJoins = objKeys(joinOptions);
 
     if (hasLength(allowedJoins)) {
-      let eagerJoins: any = {};
+      const eagerJoins: any = {};
 
       for (let i = 0; i < allowedJoins.length; i++) {
         /* istanbul ignore else */
@@ -530,6 +530,7 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
 
     return true;
   }
+
   private setAndWhere(cond: QueryFilter, i: any, builder: SelectQueryBuilder<T>) {
     this.validateHasColumn(cond.field);
     const { str, params } = this.mapOperatorsToQuery(cond, `andWhere${i}`);
@@ -594,6 +595,7 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
       ? this.mapSort(options.sort)
       : {};
   }
+
   private mapSort(sort: QuerySort[]) {
     const params: ObjectLiteral = {};
 

--- a/packages/crud-typeorm/test/1.query-params.spec.ts
+++ b/packages/crud-typeorm/test/1.query-params.spec.ts
@@ -351,5 +351,49 @@ describe('#crud-typeorm', () => {
           });
       });
     });
+
+    describe('#sort', () => {
+      it('should sort by field', async () => {
+        const query = qb.sortBy({ field: 'id', order: 'DESC' }).query();
+        const res = await request(server)
+          .get('/users')
+          .query(query)
+          .expect(200);
+        expect(res.body[1].id).toBeLessThan(res.body[0].id);
+      });
+
+      it('should sort by nested field, 1', async () => {
+        const query = qb
+          .setFilter({ field: 'company.id', operator: 'notnull' })
+          .setJoin({ field: 'company' })
+          .sortBy({ field: 'company.id', order: 'DESC' })
+          .query();
+        const res = await request(server)
+          .get('/users')
+          .query(query)
+          .expect(200);
+        expect(res.body[res.body.length - 1].company.id).toBeLessThan(
+          res.body[0].company.id,
+        );
+      });
+
+      it('should sort by nested field, 2', async () => {
+        const query = qb
+          .setFilter({ field: 'id', operator: 'eq', value: 1 })
+          .setFilter({ field: 'company.id', operator: 'notnull' })
+          .setFilter({ field: 'projects.id', operator: 'notnull' })
+          .setJoin({ field: 'company' })
+          .setJoin({ field: 'company.projects' })
+          .sortBy({ field: 'projects.id', order: 'DESC' })
+          .query();
+        const res = await request(server)
+          .get('/users')
+          .query(query)
+          .expect(200);
+        expect(res.body[0].company.projects[1].id).toBeLessThan(
+          res.body[0].company.projects[0].id,
+        );
+      });
+    });
   });
 });

--- a/packages/crud-typeorm/test/1.query-params.spec.ts
+++ b/packages/crud-typeorm/test/1.query-params.spec.ts
@@ -350,6 +350,23 @@ describe('#crud-typeorm', () => {
             done();
           });
       });
+
+      it('should return joined entity, 2', (done) => {
+        const query = qb
+          .setFilter({ field: 'company.projects.id', operator: 'notnull' })
+          .setJoin({ field: 'company' })
+          .setJoin({ field: 'company.projects' })
+          .query();
+        return request(server)
+          .get('/users/1')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.company).toBeDefined();
+            expect(res.body.company.projects).toBeDefined();
+            done();
+          });
+      });
     });
 
     describe('#sort', () => {
@@ -385,6 +402,24 @@ describe('#crud-typeorm', () => {
           .setJoin({ field: 'company' })
           .setJoin({ field: 'company.projects' })
           .sortBy({ field: 'projects.id', order: 'DESC' })
+          .query();
+        const res = await request(server)
+          .get('/users')
+          .query(query)
+          .expect(200);
+        expect(res.body[0].company.projects[1].id).toBeLessThan(
+          res.body[0].company.projects[0].id,
+        );
+      });
+
+      it('should sort by nested field, 3', async () => {
+        const query = qb
+          .setFilter({ field: 'id', operator: 'eq', value: 1 })
+          .setFilter({ field: 'company.id', operator: 'notnull' })
+          .setFilter({ field: 'projects.id', operator: 'notnull' })
+          .setJoin({ field: 'company' })
+          .setJoin({ field: 'company.projects' })
+          .sortBy({ field: 'company.projects.id', order: 'DESC' })
           .query();
         const res = await request(server)
           .get('/users')

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,10 @@
     "object-literal-sort-keys": false,
     "member-access": false,
     "no-implicit-dependencies": false,
-    "member-ordering": false
+    "member-ordering": false,
+    "prefer-for-of": false,
+    "no-submodule-imports": false,
+    "interface-name": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Actually, we already supported this in functional. But there was a bug or feature(😄) which didn't consider the `relation` as `alias`. In current design, the `relation` is `alias`. So this shall close #105 
And there is no more `Too many nested levels!`. `company.projects.id` will be transform into `projects.id` inside. So both `company.projects.id` and `projects.id` is right. Fixed #87 by getting rid of this kind of error.

@roland-chernov-akvelon maybe this is right
@chriszrc sorry to grabbing your job. When I comparing `join`, `where` and `sort`, I find the `relation` is `alias`. And `getFieldWithAlias` this method solve them all.