### PR TITLE
feat(crud-request): interceptor can work with non-crud controllers

### DIFF
--- a/packages/crud-request/src/index.ts
+++ b/packages/crud-request/src/index.ts
@@ -1,3 +1,4 @@
 export * from './request-query.builder';
+export * from './request-query.parser';
 export * from './interfaces';
 export * from './types';

--- a/packages/crud/src/interceptors/crud-request.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-request.interceptor.ts
@@ -4,33 +4,36 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { RequestQueryParser } from '@nestjsx/crud-request/lib/request-query.parser';
-
-import { R } from '../crud/reflection.helper';
+import { RequestQueryParser } from '@nestjsx/crud-request';
 import { PARSED_CRUD_REQUEST_KEY } from '../constants';
+import { R } from '../crud/reflection.helper';
 import { CrudRequest } from '../interfaces';
 
 @Injectable()
 export class CrudRequestInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler) {
     const req = context.switchToHttp().getRequest();
-    const controller = context.getClass();
-    const options = R.getCrudOptions(controller) || ({} as any);
-    const parsed = RequestQueryParser.create()
-      .parseParams(req.params, options.params)
-      .parseQuery(req.query)
-      .getParsed();
 
-    const crudReq: CrudRequest = {
-      parsed,
-      options: {
-        query: options.query,
-        routes: options.routes,
-        params: options.params,
-      },
-    };
+    /* istanbul ignore else */
+    if (!req[PARSED_CRUD_REQUEST_KEY]) {
+      const controller = context.getClass();
+      const options = R.getCrudOptions(controller) || ({} as any);
+      const parsed = RequestQueryParser.create()
+        .parseParams(req.params, options.params)
+        .parseQuery(req.query)
+        .getParsed();
 
-    req[PARSED_CRUD_REQUEST_KEY] = crudReq;
+      const crudReq: CrudRequest = {
+        parsed,
+        options: {
+          query: options.query,
+          routes: options.routes,
+          params: options.params,
+        },
+      };
+
+      req[PARSED_CRUD_REQUEST_KEY] = crudReq;
+    }
 
     return next.handle();
   }

--- a/packages/crud/src/interceptors/crud-request.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-request.interceptor.ts
@@ -15,7 +15,7 @@ export class CrudRequestInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler) {
     const req = context.switchToHttp().getRequest();
     const controller = context.getClass();
-    const options = R.getCrudOptions(controller);
+    const options = R.getCrudOptions(controller) || ({} as any);
     const parsed = RequestQueryParser.create()
       .parseParams(req.params, options.params)
       .parseQuery(req.query)

--- a/packages/crud/test/crud-request.interceptor.spec.ts
+++ b/packages/crud/test/crud-request.interceptor.spec.ts
@@ -1,0 +1,94 @@
+import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common';
+import { APP_INTERCEPTOR, NestApplication } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { RequestQueryBuilder } from '@nestjsx/crud-request';
+import * as supertest from 'supertest';
+import { ParsedRequest } from '../src/decorators';
+import { CrudRequestInterceptor } from '../src/interceptors';
+import { CrudRequest } from '../src/interfaces';
+
+describe('#crud', () => {
+  @Controller('test')
+  class TestController {
+    @Get('/query')
+    async query(@ParsedRequest() req: CrudRequest) {
+      return req;
+    }
+
+    @Get('/other')
+    async other(@Query('page', ParseIntPipe) page: number) {
+      return { page };
+    }
+  }
+
+  let $: supertest.SuperTest<supertest.Test>;
+  let app: NestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [TestController],
+      providers: [{ provide: APP_INTERCEPTOR, useClass: CrudRequestInterceptor }],
+    }).compile();
+    app = module.createNestApplication();
+    await app.init();
+
+    $ = supertest(app.getHttpServer());
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('#interceptor', () => {
+    let qb: RequestQueryBuilder;
+
+    beforeEach(() => {
+      qb = RequestQueryBuilder.create();
+    });
+
+    it('should working on non-crud controller', async () => {
+      const page = 2;
+      const limit = 10;
+      const fields = ['a', 'b', 'c'];
+      const sorts: any[][] = [['a', 'ASC'], ['b', 'DESC']];
+      const filters: any[][] = [['a', 'eq', 1], ['c', 'in', [1, 2, 3]], ['d', 'notnull']];
+
+      qb.setPage(page).setLimit(limit);
+      qb.select(fields);
+      for (const s of sorts) {
+        qb.sortBy({ field: s[0], order: s[1] });
+      }
+      for (const f of filters) {
+        qb.setFilter({ field: f[0], operator: f[1], value: f[2] });
+      }
+
+      const res = await $.get('/test/query')
+        .query(qb.query())
+        .expect(200);
+
+      // console.log(qb.query(), JSON.stringify(res.body));
+
+      expect(res.body.parsed).toHaveProperty('page', page);
+      expect(res.body.parsed).toHaveProperty('limit', limit);
+      expect(res.body.parsed).toHaveProperty('fields', fields);
+      expect(res.body.parsed).toHaveProperty('sort');
+      for (let i = 0; i < sorts.length; i++) {
+        expect(res.body.parsed.sort[i]).toHaveProperty('field', sorts[i][0]);
+        expect(res.body.parsed.sort[i]).toHaveProperty('order', sorts[i][1]);
+      }
+      expect(res.body.parsed).toHaveProperty('filter');
+      for (let i = 0; i < filters.length; i++) {
+        expect(res.body.parsed.filter[i]).toHaveProperty('field', filters[i][0]);
+        expect(res.body.parsed.filter[i]).toHaveProperty('operator', filters[i][1]);
+        expect(res.body.parsed.filter[i]).toHaveProperty('value', filters[i][2] || '');
+      }
+    });
+
+    it('should others working', async () => {
+      const res = await $.get('/test/other')
+        .query({ page: 2, per_page: 11 })
+        .expect(200);
+      expect(res.body.page).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Now the crud query syntax can be used in everywhere. 
The non-crud controllers can get the benefit too.