### PR TITLE
less strict uuid validator

### DIFF
--- a/packages/crud-request/src/request-query.validator.ts
+++ b/packages/crud-request/src/request-query.validator.ts
@@ -102,7 +102,7 @@ export function validateParamOption(options: ParamsOptions, name: string) {
 }
 
 export function validateUUID(str: string, name: string) {
-  const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   if (!uuid.test(str)) {
     throw new RequestQueryException(`Invalid param ${name}. UUID string expected`);
   }


### PR DESCRIPTION
changed the Regex to validate uuid generated by mssql, since it's not following the v4 uuid standard.