### PR TITLE
feat: add compound filters

### DIFF
--- a/packages/crud-request/src/interfaces/parsed-request.interface.ts
+++ b/packages/crud-request/src/interfaces/parsed-request.interface.ts
@@ -1,8 +1,8 @@
-import { QueryFields, QueryFilter, QueryJoin, QuerySort } from '../types';
+import { QueryFields, QueryFilter, QueryJoin, QueryOperation, QuerySort } from '../types';
 
 export interface ParsedRequestParams {
   fields: QueryFields;
-  paramsFilter: QueryFilter[];
+  paramsFilter: QueryOperation[];
   filter: QueryFilter[];
   or: QueryFilter[];
   join: QueryJoin[];

--- a/packages/crud-request/src/request-query.builder.ts
+++ b/packages/crud-request/src/request-query.builder.ts
@@ -1,13 +1,13 @@
 import {
   hasLength,
   hasValue,
-  isObject,
-  isString,
   isArrayFull,
   isNil,
+  isObject,
+  isString,
 } from '@nestjsx/util';
 
-import { RequestQueryBuilderOptions, CreateQueryParams } from './interfaces';
+import { CreateQueryParams, RequestQueryBuilderOptions } from './interfaces';
 import {
   validateCondition,
   validateFields,
@@ -15,7 +15,7 @@ import {
   validateNumeric,
   validateSort,
 } from './request-query.validator';
-import { QueryFields, QueryFilter, QueryJoin, QuerySort } from './types';
+import { QueryFields, QueryFilter, QueryJoin, QueryOperation, QuerySort } from './types';
 
 // tslint:disable:variable-name ban-types
 export class RequestQueryBuilder {
@@ -209,12 +209,18 @@ export class RequestQueryBuilder {
       this[`_${cond}`]
         .map(
           (f: QueryFilter) =>
-            `${param}${br}=${f.field}${d}${f.operator}${
-              hasValue(f.value) ? d + f.value : ''
+            `${param}${br}=${
+              Array.isArray(f)
+                ? JSON.stringify(f.map((s) => this.generateQuery(s, d)))
+                : this.generateQuery(f, d)
             }`,
         )
         .join('&') + '&'
     );
+  }
+
+  private generateQuery(f: QueryOperation, d: string) {
+    return `${f.field}${d}${f.operator}${hasValue(f.value) ? d + f.value : ''}`;
   }
 
   private getJoin(): string {

--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -197,7 +197,7 @@ export class RequestQueryParser implements ParsedRequestParams {
   }
 
   private conditionParser(cond: 'filter' | 'or', data: string): QueryFilter {
-    let objectData: string | string[];
+    let objectData: string | object[];
     try {
       objectData = JSON.parse(data);
       // tslint:disable-next-line

--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -197,22 +197,25 @@ export class RequestQueryParser implements ParsedRequestParams {
   }
 
   private conditionParser(cond: 'filter' | 'or', data: string): QueryFilter {
+    let objectData: string | string[];
     try {
-      const objectData = JSON.parse(data);
-
+      objectData = JSON.parse(data);
+      // tslint:disable-next-line
+    } catch (e) {}
+    if (objectData !== undefined) {
       if (Array.isArray(objectData)) {
         if (objectData.length === 1) {
-          return this.conditionParser(cond, objectData[0]);
+          return this.conditionParser(cond, JSON.stringify(objectData[0]));
         }
 
         return objectData.map((o) =>
-          this.conditionParser(cond === 'filter' ? 'or' : 'filter', JSON.stringify(o)),
+          this.conditionParser(cond, JSON.stringify(o)),
         ) as QueryFilter;
       } else {
         return this.conditionParser(cond, objectData);
       }
-      // tslint:disable-next-line
-    } catch (e) {}
+    }
+
     const isArrayValue = ['in', 'notin', 'between'];
     const isEmptyValue = ['isnull', 'notnull'];
     const param = data.split(this._options.delim);

--- a/packages/crud-request/src/request-query.validator.ts
+++ b/packages/crud-request/src/request-query.validator.ts
@@ -1,6 +1,7 @@
 import {
   isUndefined,
   isArrayStrings,
+  isArrayFull,
   isStringFull,
   isObject,
   isEqual,
@@ -47,6 +48,10 @@ export function validateFields(fields: QueryFields): void {
 }
 
 export function validateCondition(val: QueryFilter, cond: 'filter' | 'or'): void {
+  if (Array.isArray(val)) {
+    return val.forEach((v) => this.validateCondition(v, cond));
+  }
+
   if (!isObject(val) || !isStringFull(val.field)) {
     throw new RequestQueryException(`Invalid ${cond} field. String expected`);
   }

--- a/packages/crud-request/src/types/request-query.types.ts
+++ b/packages/crud-request/src/types/request-query.types.ts
@@ -1,6 +1,8 @@
 export type QueryFields = string[];
 
-export type QueryFilter = {
+export type QueryFilter = QueryOperation | QueryOperation[];
+
+export type QueryOperation = {
   field: string;
   operator: ComparisonOperator;
   value?: any;

--- a/packages/crud-request/test/request-query.builder.spec.ts
+++ b/packages/crud-request/test/request-query.builder.spec.ts
@@ -205,12 +205,39 @@ describe('#request-query', () => {
         const expected = 'filter=foo||eq||test';
         expect(test).toBe(expected);
       });
-      it('should return query with or conditions', () => {
+      it('should return query with filter conditions, 3', () => {
+        const test = qb
+          .setFilter([{ field: 'foo', operator: 'eq', value: 'test' }])
+          .query();
+        const expected = 'filter=["foo||eq||test"]';
+        expect(test).toBe(expected);
+      });
+      it('should return query with filter conditions, 4', () => {
+        const test = qb
+          .setFilter([
+            { field: 'foo', operator: 'eq', value: 'test' },
+            { field: 'bar', operator: 'eq', value: 'test2' },
+          ])
+          .query();
+        const expected = 'filter=["foo||eq||test","bar||eq||test2"]';
+        expect(test).toBe(expected);
+      });
+      it('should return query with or conditions 1', () => {
         const test = qb
           .setOr({ field: 'foo', operator: 'eq', value: 'test' })
           .setOr({ field: 'bar', operator: 'notnull' })
           .query();
         const expected = 'or[]=foo||eq||test&or[]=bar||notnull';
+        expect(test).toBe(expected);
+      });
+      it('should return query with or conditions, 2', () => {
+        const test = qb
+          .setOr([
+            { field: 'foo', operator: 'eq', value: 'test' },
+            { field: 'bar', operator: 'eq', value: 'test2' },
+          ])
+          .query();
+        const expected = 'or=["foo||eq||test","bar||eq||test2"]';
         expect(test).toBe(expected);
       });
       it('should return query with join', () => {

--- a/packages/crud-request/test/request-query.parser.spec.ts
+++ b/packages/crud-request/test/request-query.parser.spec.ts
@@ -71,6 +71,14 @@ describe('#request-query', () => {
           const query = { filter: 'foo||eq' };
           expect(qp.parseQuery.bind(qp, query)).toThrowError(RequestQueryException);
         });
+        it('should throw an error, 3', () => {
+          const query = { filter: '["foo||eq"]' };
+          expect(qp.parseQuery.bind(qp, query)).toThrowError(RequestQueryException);
+        });
+        it('should throw an error, 4', () => {
+          const query = { filter: '["foo||eq||1","foo||eq"]' };
+          expect(qp.parseQuery.bind(qp, query)).toThrowError(RequestQueryException);
+        });
         it('should set array, 1', () => {
           const query = { filter: 'foo||eq||bar' };
           const expected: QueryFilter[] = [

--- a/packages/crud-request/test/request-query.parser.spec.ts
+++ b/packages/crud-request/test/request-query.parser.spec.ts
@@ -11,7 +11,7 @@ describe('#request-query', () => {
       qp = RequestQueryParser.create();
     });
 
-    describe('#parseQury', () => {
+    describe('#parseQuery', () => {
       it('should return instance of RequestQueryParse', () => {
         expect((qp as any).parseQuery()).toBeInstanceOf(RequestQueryParser);
         expect((qp as any).parseQuery({})).toBeInstanceOf(RequestQueryParser);
@@ -53,6 +53,12 @@ describe('#request-query', () => {
         });
         it('should set empty array, 2', () => {
           const query = { foo: '' };
+          const expected = [];
+          const test = qp.parseQuery(query);
+          expect(test.filter).toMatchObject(expected);
+        });
+        it('should set empty array, 3', () => {
+          const query = { foo: '[]' };
           const expected = [];
           const test = qp.parseQuery(query);
           expect(test.filter).toMatchObject(expected);
@@ -142,6 +148,47 @@ describe('#request-query', () => {
           const test = qp.parseQuery(query);
           expect(test.filter[0]).toMatchObject(expected[0]);
         });
+        it('should set compound array, 1', () => {
+          const query = { filter: ['["foo||eq||1"]'] };
+          const expected: QueryFilter[] = [{ field: 'foo', operator: 'eq', value: 1 }];
+          const test = qp.parseQuery(query);
+          expect(test.filter[0]).toMatchObject(expected[0]);
+        });
+        it('should set compound array, 2', () => {
+          const query = { filter: ['["foo||eq||1","bar||eq||1"]'] };
+          const expected: QueryFilter[] = [
+            [
+              { field: 'foo', operator: 'eq', value: 1 },
+              { field: 'bar', operator: 'eq', value: 1 },
+            ],
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.filter[0]).toMatchObject(expected[0]);
+        });
+        it('should set compound array, 3', () => {
+          const query = { filter: ['["foo||eq||1","bar||eq||1"]', '["foo||eq||2"]'] };
+          const expected: QueryFilter[] = [
+            [
+              { field: 'foo', operator: 'eq', value: 1 },
+              { field: 'bar', operator: 'eq', value: 1 },
+            ],
+            [{ field: 'foo', operator: 'eq', value: 2 }],
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.filter[0]).toMatchObject(expected[0]);
+        });
+        it('should set compound array, 4', () => {
+          const query = { filter: ['["foo||eq||1","bar||eq||1"]', 'foo||eq||2'] };
+          const expected: QueryFilter[] = [
+            [
+              { field: 'foo', operator: 'eq', value: 1 },
+              { field: 'bar', operator: 'eq', value: 1 },
+            ],
+            { field: 'foo', operator: 'eq', value: 2 },
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.filter[0]).toMatchObject(expected[0]);
+        });
       });
 
       describe('#parse or', () => {
@@ -153,6 +200,12 @@ describe('#request-query', () => {
         });
         it('should set empty array, 2', () => {
           const query = { foo: '' };
+          const expected = [];
+          const test = qp.parseQuery(query);
+          expect(test.or).toMatchObject(expected);
+        });
+        it('should set empty array, 3', () => {
+          const query = { foo: '[]' };
           const expected = [];
           const test = qp.parseQuery(query);
           expect(test.or).toMatchObject(expected);
@@ -195,6 +248,41 @@ describe('#request-query', () => {
           const query = { or: ['foo||isnull'] };
           const expected: QueryFilter[] = [
             { field: 'foo', operator: 'isnull', value: '' },
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.or[0]).toMatchObject(expected[0]);
+        });
+        it('should set compound array, 1', () => {
+          const query = { or: ['["foo||eq||1","bar||eq||2"]'] };
+          const expected: QueryFilter[] = [
+            [
+              { field: 'foo', operator: 'eq', value: 1 },
+              { field: 'bar', operator: 'eq', value: 2 },
+            ],
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.or[0]).toMatchObject(expected[0]);
+        });
+        it('should set compound array, 2', () => {
+          const query = { or: ['["foo||eq||1","bar||eq||1"]', '["foo||eq||2"]'] };
+          const expected: QueryFilter[] = [
+            [
+              { field: 'foo', operator: 'eq', value: 1 },
+              { field: 'bar', operator: 'eq', value: 1 },
+            ],
+            [{ field: 'foo', operator: 'eq', value: 2 }],
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.or[0]).toMatchObject(expected[0]);
+        });
+        it('should set compound array, 3', () => {
+          const query = { or: ['["foo||eq||1","bar||eq||1"]', 'foo||eq||2'] };
+          const expected: QueryFilter[] = [
+            [
+              { field: 'foo', operator: 'eq', value: 1 },
+              { field: 'bar', operator: 'eq', value: 1 },
+            ],
+            { field: 'foo', operator: 'eq', value: 2 },
           ];
           const test = qp.parseQuery(query);
           expect(test.or[0]).toMatchObject(expected[0]);

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -532,8 +532,6 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
   ) {
     if (!isArrayFull(filters)) {
       return this.setAndWhere(filters, name, builder);
-    } else if (filters.length === 1) {
-      return this.setAndWhere(filters[0], name, builder);
     }
 
     builder.andWhere(
@@ -552,8 +550,6 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
   ) {
     if (!isArrayFull(filters)) {
       return this.setOrWhere(filters, name, builder);
-    } else if (filters.length === 1) {
-      return this.setOrWhere(filters[0], name, builder);
     }
 
     builder.orWhere(

--- a/packages/crud-typeorm/test/1.query-params.spec.ts
+++ b/packages/crud-typeorm/test/1.query-params.spec.ts
@@ -203,7 +203,7 @@ describe('#crud-typeorm', () => {
             done();
           });
       });
-      it('should return with filter and or, 6', (done) => {
+      it('should return with filter and or, 5', (done) => {
         const query = qb.setOr({ field: 'companyId', operator: 'isnull' }).query();
         return request(server)
           .get('/projects')
@@ -235,6 +235,131 @@ describe('#crud-typeorm', () => {
           .end((_, res) => {
             expect(res.status).toBe(200);
             expect(res.body.length).toBe(2);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 1', (done) => {
+        const query = qb
+          .setFilter([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'companyId', operator: 'eq', value: 2 },
+          ])
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(4);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 2', (done) => {
+        const query = qb
+          .setFilter([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'companyId', operator: 'eq', value: 2 },
+          ])
+          .setFilter([
+            { field: 'companyId', operator: 'eq', value: 2 },
+            { field: 'companyId', operator: 'eq', value: 3 },
+          ])
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(2);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 3', (done) => {
+        const query = qb
+          .setOr([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'description', operator: 'eq', value: 'description1' },
+          ])
+          .setOr([{ field: 'companyId', operator: 'eq', value: 2 }])
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(3);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 4', (done) => {
+        const query = qb
+          .setOr([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'description', operator: 'eq', value: 'description1' },
+          ])
+          .setOr({ field: 'companyId', operator: 'eq', value: 2 })
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(3);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 5', (done) => {
+        const query = qb
+          .setFilter([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'companyId', operator: 'eq', value: 2 },
+          ])
+          .setOr([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'description', operator: 'eq', value: 'description1' },
+          ])
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(4);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 6', (done) => {
+        const query = qb
+          .setFilter([{ field: 'companyId', operator: 'eq', value: 1 }])
+          .setFilter({ field: 'companyId', operator: 'eq', value: 2 })
+          .setOr([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'description', operator: 'eq', value: 'description1' },
+          ])
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(1);
+            done();
+          });
+      });
+      it('should return with compound filter and or, 7', (done) => {
+        const query = qb
+          .setFilter([
+            { field: 'companyId', operator: 'eq', value: 1 },
+            { field: 'description', operator: 'eq', value: 'bad_description' },
+          ])
+          .setOr({ field: 'companyId', operator: 'eq', value: 3 })
+          .query();
+        return request(server)
+          .get('/projects')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.length).toBe(4);
             done();
           });
       });
@@ -364,6 +489,86 @@ describe('#crud-typeorm', () => {
             expect(res.status).toBe(200);
             expect(res.body.company).toBeDefined();
             expect(res.body.company.projects).toBeDefined();
+            done();
+          });
+      });
+
+      it('should return joined entity with compound filter, 1', (done) => {
+        const query = qb
+          .setFilter({ field: 'company.projects.id', operator: 'eq', value: 1 })
+          .setOr([
+            { field: 'company.projects.companyId', operator: 'eq', value: '3' },
+            {
+              field: 'company.projects.description',
+              operator: 'cont',
+              value: 'description',
+            },
+          ])
+          .setJoin({ field: 'company' })
+          .setJoin({ field: 'company.projects' })
+          .query();
+        return request(server)
+          .get('/users/1')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.company).toBeDefined();
+            expect(res.body.company.projects.length).toEqual(1);
+            done();
+          });
+      });
+
+      it('should return joined entity with compound filter, 2', (done) => {
+        const query = qb
+          .setFilter([
+            { field: 'company.projects.id', operator: 'eq', value: 1 },
+            { field: 'company.projects.id', operator: 'eq', value: 2 },
+          ])
+          .setFilter([
+            { field: 'company.projects.companyId', operator: 'in', value: [1, 2, 3] },
+            {
+              field: 'company.projects.description',
+              operator: 'cont',
+              value: 'description',
+            },
+          ])
+          .setJoin({ field: 'company' })
+          .setJoin({ field: 'company.projects' })
+          .query();
+        return request(server)
+          .get('/users/1')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.company).toBeDefined();
+            expect(res.body.company.projects.length).toEqual(2);
+            done();
+          });
+      });
+
+      it('should return joined entity with compound filter, 3', (done) => {
+        const query = qb
+          .setFilter({ field: 'company.projects.id', operator: 'in', value: [1, 2] })
+          .setFilter({ field: 'company.projects.id', operator: 'eq', value: 1 })
+          .setOr([
+            { field: 'company.projects.companyId', operator: 'eq', value: '3' },
+            {
+              field: 'company.projects.description',
+              operator: 'cont',
+              value: 'description',
+            },
+          ])
+          .setJoin({ field: 'company' })
+          .setJoin({ field: 'company.projects' })
+          .query();
+
+        return request(server)
+          .get('/users/1')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.company).toBeDefined();
+            expect(res.body.company.projects.length).toEqual(1);
             done();
           });
       });

--- a/packages/util/src/checks.util.ts
+++ b/packages/util/src/checks.util.ts
@@ -1,24 +1,27 @@
 import { objKeys } from './obj.util';
 
-export const isUndefined = (val: any): boolean => typeof val === 'undefined';
-export const isNull = (val: any): boolean => val === null;
+export const isUndefined = (val: any): val is undefined => typeof val === 'undefined';
+export const isNull = (val: any): val is null => val === null;
 export const isNil = (val: any): boolean => isUndefined(val) || isNull(val);
-export const isString = (val: any): boolean => typeof val === 'string';
+export const isString = (val: any): val is string => typeof val === 'string';
 export const hasLength = (val: any): boolean => val.length > 0;
-export const isStringFull = (val: any): boolean => isString(val) && hasLength(val);
-export const isArrayFull = (val: any): boolean => Array.isArray(val) && hasLength(val);
-export const isArrayStrings = (val: any): boolean =>
+export const isStringFull = (val: any): val is string => isString(val) && hasLength(val);
+export const isArrayFull = (val: any): val is any[] =>
+  Array.isArray(val) && hasLength(val);
+export const isArrayStrings = (val: any): val is string[] =>
   isArrayFull(val) && (val as string[]).every((v) => isStringFull(v));
-export const isObject = (val: any): boolean => typeof val === 'object' && !isNull(val);
-export const isObjectFull = (val: any) => isObject(val) && hasLength(objKeys(val));
-export const isNumber = (val: any): boolean =>
+export const isObject = (val: any): val is object =>
+  typeof val === 'object' && !isNull(val);
+export const isObjectFull = (val: any): val is object =>
+  isObject(val) && hasLength(objKeys(val));
+export const isNumber = (val: any): val is number =>
   typeof val === 'number' && !Number.isNaN(val) && Number.isFinite(val);
 export const isEqual = (val: any, eq: any): boolean => val === eq;
 export const isFalse = (val: any): boolean => val === false;
 export const isTrue = (val: any): boolean => val === true;
 export const isIn = (val: any, arr: any[] = []): boolean =>
   arr.some((o) => isEqual(val, o));
-export const isBoolean = (val: any): boolean => typeof val === 'boolean';
+export const isBoolean = (val: any): val is boolean => typeof val === 'boolean';
 export const isNumeric = (val: any): boolean => /^[+-]?([0-9]*[.])?[0-9]+$/.test(val);
 export const isDateString = (val: any): boolean =>
   isStringFull(val) &&


### PR DESCRIPTION
resolve #110 

add possibility to compound filters, by passing a JSON array of filters:

```
?filter[]=["id||eq||1","id||eq||2"]
&filter[]=firstname||cont||pie
```
will give 
```sql
WHERE ( id=1 OR id=2) AND (firstname LIKE '%pie%')
```

the inverse for OR:
```
?or[]=["id||eq||1","id||eq||2"]
&or[]=firstname||cont||pie
```
will give 
```sql
WHERE ( id=1 AND id=2) OR (firstname LIKE '%pie%')
```

And if we mix both:
```
?or[]=id||eq||1,id||eq||2
&or[]=firstname||cont||pie
&filter[]=companyId||eq||5
&filter[]=["teamId||eq||1","team2Id||eq||2"] 
```
we will have 
```sql
WHERE companyId=5 AND (teamId=1 OR team2Id=2) OR (( id=1 AND id=2) OR (firstname LIKE '%pie%'))
```
I haven't tried multi levels, but it could work
I coded it with TTD, it needs some IRL tests :)