### PR TITLE
fix(crud-typeorm): beforeUpdate and afterUpdate events

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -132,7 +132,9 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
       }
     }
 
-    return this.repo.save<any>({ ...found, ...dto });
+    return this.repo.save<any>(
+      plainToClass(this.entityType, { ...found, ...dto }) /* Object.assign(found, dto) */,
+    );
   }
 
   /**


### PR DESCRIPTION
Resolves #51

I've suggested another fix as a comment. Problem was that the { ...found, ...dto } compiled to Object.assign({}, found, dto) (intentionally), which meant that it was a plain class. Whenever TypeORM checked whether it was the correct type, it wasn't.