### PR TITLE
fix(crud-typeorm): selected columns in composite key join

### DIFF
--- a/integration/crud-typeorm/seeds.ts
+++ b/integration/crud-typeorm/seeds.ts
@@ -91,6 +91,26 @@ export class Seeds1544303473346 implements MigrationInterface {
       ('19@email.com', false, 2, 19),
       ('20@email.com', false, 2, 20);
     `);
+
+    // licenses
+    await queryRunner.query(`
+      INSERT INTO public.licenses ("name") VALUES
+      ('License1'),
+      ('License2'),
+      ('License3'),
+      ('License4'),
+      ('License5');
+    `);
+
+    // licenses
+    await queryRunner.query(`
+      INSERT INTO public.user_licenses ("userId", "licenseId", "yearsActive") VALUES
+      (1, 1, 3),
+      (1, 2, 5),
+      (1, 4, 7),
+      (2, 5, 1);
+    `);
+
   }
 
   public async down(queryRunner: QueryRunner): Promise<any> {}

--- a/integration/crud-typeorm/users-licenses/index.ts
+++ b/integration/crud-typeorm/users-licenses/index.ts
@@ -1,0 +1,2 @@
+export * from './license.entity';
+export * from './user-license.entity';

--- a/integration/crud-typeorm/users-licenses/license.entity.ts
+++ b/integration/crud-typeorm/users-licenses/license.entity.ts
@@ -1,0 +1,14 @@
+import { Column, Entity } from 'typeorm';
+import { BaseEntity } from '../base-entity';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+@Entity('licenses')
+export class License extends BaseEntity {
+
+  @IsOptional({ always: true })
+  @IsString({ always: true })
+  @MaxLength(32, { always: true })
+  @Column({ type: 'varchar', length: 32, nullable: true, default: null })
+  name: string;
+
+}

--- a/integration/crud-typeorm/users-licenses/user-license.entity.ts
+++ b/integration/crud-typeorm/users-licenses/user-license.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, ManyToOne, PrimaryColumn } from 'typeorm';
+import { User } from '../users/user.entity';
+import { Type } from 'class-transformer';
+import { License } from './license.entity';
+
+@Entity('user_licenses')
+export class UserLicense {
+
+  @PrimaryColumn()
+  userId: number;
+
+  @PrimaryColumn()
+  licenseId: number;
+
+  @ManyToOne(type => User)
+  @Type(t => User)
+  user: User;
+
+  @ManyToOne(type => License)
+  @Type(t => License)
+  license: License;
+
+  @Column()
+  yearsActive: number;
+
+}

--- a/integration/crud-typeorm/users/user.entity.ts
+++ b/integration/crud-typeorm/users/user.entity.ts
@@ -1,13 +1,5 @@
-import { Entity, Column, JoinColumn, OneToOne, ManyToOne, ManyToMany } from 'typeorm';
-import {
-  IsOptional,
-  IsString,
-  MaxLength,
-  IsNotEmpty,
-  IsEmail,
-  IsBoolean,
-  ValidateNested,
-} from 'class-validator';
+import { Column, Entity, JoinColumn, ManyToMany, ManyToOne, OneToMany, OneToOne } from 'typeorm';
+import { IsBoolean, IsEmail, IsNotEmpty, IsOptional, IsString, MaxLength, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { CrudValidationGroups } from '@nestjsx/crud';
 
@@ -15,6 +7,7 @@ import { BaseEntity } from '../base-entity';
 import { UserProfile } from '../users-profiles/user-profile.entity';
 import { Company } from '../companies/company.entity';
 import { Project } from '../projects/project.entity';
+import { UserLicense } from '../users-licenses/user-license.entity';
 
 const { CREATE, UPDATE } = CrudValidationGroups;
 
@@ -57,4 +50,9 @@ export class User extends BaseEntity {
 
   @ManyToMany((type) => Project, (c) => c.users)
   projects?: Project[];
+
+  @OneToMany((type) => UserLicense, (ul) => ul.user)
+  @Type((t) => UserLicense)
+  @JoinColumn()
+  userLicenses?: UserLicense[];
 }

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -412,10 +412,10 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
   private validateHasColumn(column: string) {
     if (column.indexOf('.') !== -1) {
       const nests = column.split('.');
-      let relation;
       column = nests[nests.length - 1];
-      relation = nests.slice(0, nests.length - 1).join('.');
 
+      // relation could be deep (ex: company.projects.id), hash is flat
+      const relation = nests.slice(nests.length - 2, nests.length - 1).join('');
       if (!this.hasRelation(relation)) {
         this.throwBadRequestException(`Invalid relation name '${relation}'`);
       }

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -201,7 +201,7 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     // create query builder
     const builder = this.repo.createQueryBuilder(this.alias);
 
-    // get selet fields
+    // get select fields
     const select = this.getSelect(parsed, options.query);
 
     // select fields
@@ -345,6 +345,9 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
           name: curr.propertyName,
           type: this.getJoinType(curr.relationType),
           columns: curr.inverseEntityMetadata.columns.map((col) => col.propertyName),
+          primaryColumns: curr.inverseEntityMetadata.primaryColumns.map(
+            (col) => col.propertyName,
+          ),
           referencedColumn: (curr.joinColumns.length
             ? curr.joinColumns[0]
             : curr.inverseRelation.joinColumns[0]
@@ -489,6 +492,9 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
         name: curr.propertyName,
         type: this.getJoinType(curr.relationType),
         columns: curr.inverseEntityMetadata.columns.map((col) => col.propertyName),
+        primaryColumns: curr.inverseEntityMetadata.primaryColumns.map(
+          (col) => col.propertyName,
+        ),
         referencedColumn: (curr.joinColumns.length
           ? /* istanbul ignore next */ curr.joinColumns[0]
           : curr.inverseRelation.joinColumns[0]
@@ -514,7 +520,7 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
           : cond.select.filter((col) => allowed.some((a) => a === col));
 
       const select = [
-        relation.referencedColumn,
+        ...relation.primaryColumns,
         ...(options.persist && options.persist.length ? options.persist : []),
         ...columns,
       ].map((col) => `${relation.name}.${col}`);

--- a/packages/crud-typeorm/test/1.query-params.spec.ts
+++ b/packages/crud-typeorm/test/1.query-params.spec.ts
@@ -352,7 +352,7 @@ describe('#crud-typeorm', () => {
           });
       });
 
-      fit('should return joined entity, 2', (done) => {
+      it('should return joined entity, 2', (done) => {
         const query = qb
           .setFilter({ field: 'company.projects.id', operator: 'notnull' })
           .setJoin({ field: 'company' })

--- a/packages/crud-typeorm/test/1.query-params.spec.ts
+++ b/packages/crud-typeorm/test/1.query-params.spec.ts
@@ -67,6 +67,7 @@ describe('#crud-typeorm', () => {
         join: {
           company: {},
           'company.projects': {},
+          userLicenses: {},
         },
       },
     })
@@ -351,7 +352,7 @@ describe('#crud-typeorm', () => {
           });
       });
 
-      it('should return joined entity, 2', (done) => {
+      fit('should return joined entity, 2', (done) => {
         const query = qb
           .setFilter({ field: 'company.projects.id', operator: 'notnull' })
           .setJoin({ field: 'company' })
@@ -364,6 +365,20 @@ describe('#crud-typeorm', () => {
             expect(res.status).toBe(200);
             expect(res.body.company).toBeDefined();
             expect(res.body.company.projects).toBeDefined();
+            done();
+          });
+      });
+    });
+
+    describe('#composite key join', () => {
+      it('should return joined relation', (done) => {
+        const query = qb.setJoin({ field: 'userLicenses' }).query();
+        return request(server)
+          .get('/users/1')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.userLicenses).toBeDefined();
             done();
           });
       });


### PR DESCRIPTION
adjusted selected columns in the join to include the primary columns on the relation, instead of using the referenced primary column on the left-side table (which doesn't exist for composite key joins)

Note: I have a test that adds a user - license composite key join relationship to exercise this change, and somehow that new fixture broke this other test --> ``should return joined entity, 2``. On master when this test runs, the only column which is validated is 'id'.  After the new test was added for the composite key, 'company.projects.id' is now being passed to the validator. I made an additional code change to address that, assuming that there was something janky going on before. Here is the bit that addresses the validator when a nested column is passed into it:

```ts
      // relation could be deep (ex: company.projects.id), hash is flat
      const relation = nests.slice(nests.length - 2, nests.length - 1).join('');
```
