### PR TITLE
fix: allows an array of filter's and or's in Swagger API

### DIFF
--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -117,6 +117,8 @@ export class Swagger {
       required: false,
       in: 'query',
       type: String,
+      isArray: true,
+      collectionFormat: 'multi',
     };
     const orMeta = {
       name: or,
@@ -125,6 +127,8 @@ export class Swagger {
       required: false,
       in: 'query',
       type: String,
+      isArray: true,
+      collectionFormat: 'multi',
     };
     const sortMeta = {
       name: sort,


### PR DESCRIPTION
Fixes the issue with Swagger metadata that did not allow to use an array of `filter` and `or` in TypeScript client.

**Actual behavior:**
Generated API client did not allow specifying an array of `filter` and `or`

![CRUD_BEFORE](https://user-images.githubusercontent.com/4927804/65332466-6fab8f80-dbc7-11e9-81f9-3b060c1d83f6.png)

**Expected behavior:**
Generated API client allows specifying an array of `filter` and `or`

![CRUD_AFTER](https://user-images.githubusercontent.com/4927804/65332488-76d29d80-dbc7-11e9-9653-01bb34e494b3.png)

**Generated TS client:**

![CRUD_generated_dts](https://user-images.githubusercontent.com/4927804/65332499-7e924200-dbc7-11e9-8f62-67f51e67dece.png)

**Generated JS client:**
![CRUD_generated_js](https://user-images.githubusercontent.com/4927804/65332535-8baf3100-dbc7-11e9-969e-6a37fe303e58.png)
