### PR TITLE
Fix incorrect parsing of  integer ids when paramter type is string

### DIFF
--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -254,10 +254,11 @@ export class RequestQueryParser implements ParsedRequestParams {
   private paramParser(name: string): QueryFilter {
     validateParamOption(this._paramsOptions, name);
     const option = this._paramsOptions[name];
-    const value = this.parseValue(this._params[name]);
+    let value = this._params[name];
 
     switch (option.type) {
       case 'number':
+        value = this.parseValue(value);
         validateNumeric(value, `param ${name}`);
         break;
       case 'uuid':

--- a/packages/crud-request/test/request-query.parser.spec.ts
+++ b/packages/crud-request/test/request-query.parser.spec.ts
@@ -410,17 +410,20 @@ describe('#request-query', () => {
           foo: 'cb1751fd-7fcf-4eb5-b38e-86428b1fd88d',
           bar: '1',
           buz: 'string',
+          bigInt: '9007199254740999', // Bigger than Number.MAX_SAFE_INTEGER
         };
         const options: ParamsOptions = {
           foo: { field: 'foo', type: 'uuid' },
           bar: { field: 'bb', type: 'number' },
           buz: { field: 'buz', type: 'string' },
+          bigInt: { field: 'bigInt', type: 'string' },
         };
         const test = qp.parseParams(params, options);
         const expected = [
           { field: 'foo', operator: 'eq', value: 'cb1751fd-7fcf-4eb5-b38e-86428b1fd88d' },
           { field: 'bb', operator: 'eq', value: 1 },
           { field: 'buz', operator: 'eq', value: 'string' },
+          { field: 'bigInt', operator: 'eq', value: '9007199254740999' },
         ];
         expect(test.paramsFilter).toMatchObject(expected);
       });


### PR DESCRIPTION
Resolves #245.
For models with bigint primary keys, and PK param type specified as 'string', the request parser still parses the key to Number. This is incorrect as JS Number cannot hold safely a bigint.

This fix, parses the parameter value to string only in case the parameter type is 'number'.

See #245 for more details.