### PR TITLE
Join on a ManyToMany pivot table

### DIFF
--- a/integration/crud-typeorm/projects/project.entity.ts
+++ b/integration/crud-typeorm/projects/project.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, Column, ManyToOne, ManyToMany, JoinTable, OneToMany } from 'typeorm';
 import {
   IsOptional,
   IsString,
@@ -12,6 +12,7 @@ import { CrudValidationGroups } from '@nestjsx/crud';
 import { BaseEntity } from '../base-entity';
 import { Company } from '../companies/company.entity';
 import { User } from '../users/user.entity';
+import { UserProject } from './userProject.entity';
 
 const { CREATE, UPDATE } = CrudValidationGroups;
 
@@ -46,6 +47,20 @@ export class Project extends BaseEntity {
   company?: Company;
 
   @ManyToMany((type) => User, (u) => u.projects, { cascade: true })
-  @JoinTable()
+  @JoinTable({
+    name: 'user_projects',
+    joinColumn: {
+      name: 'projectId',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'userId',
+      referencedColumnName: 'id',
+    },
+  })
   users?: User[];
+
+  @OneToMany((type) => UserProject, (el) => el.project, { persistence: false, onDelete: 'CASCADE' })
+  userProjects!: UserProject[];
+
 }

--- a/integration/crud-typeorm/projects/userProject.entity.ts
+++ b/integration/crud-typeorm/projects/userProject.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, Column, ManyToOne, PrimaryColumn } from 'typeorm';
+
+import { User } from '../users/user.entity';
+import { Project } from './project.entity';
+
+
+@Entity('user_projects')
+export class UserProject {
+
+  @PrimaryColumn()
+  public projectId!: number;
+
+  @PrimaryColumn()
+  public userId!: number;
+
+  @Column({ nullable: true })
+  public review!: string;
+
+  @ManyToOne(type => Project, (el) => el.userProjects, { primary: true, persistence: false, onDelete: 'CASCADE' })
+  public project: Project;
+
+  @ManyToOne(type => User, (el) => el.userProjects, { primary: true, persistence: false })
+  public user: User;
+
+}

--- a/integration/crud-typeorm/seeds.ts
+++ b/integration/crud-typeorm/seeds.ts
@@ -91,6 +91,15 @@ export class Seeds1544303473346 implements MigrationInterface {
       ('19@email.com', false, 2, 19),
       ('20@email.com', false, 2, 20);
     `);
+
+    // userProjects
+    await queryRunner.query(`
+      INSERT INTO public.user_projects ("projectId", "userId", "review") VALUES
+      (1, 1, 'User project 1 1'),
+      (1, 2, 'User project 1 2'),
+      (2, 2, 'User project 2 2'),
+      (3, 3, 'User project 3 3');
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<any> {}

--- a/integration/crud-typeorm/users/user.entity.ts
+++ b/integration/crud-typeorm/users/user.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, JoinColumn, OneToOne, ManyToOne, ManyToMany } from 'typeorm';
+import { Entity, Column, JoinColumn, OneToOne, ManyToOne, ManyToMany, OneToMany } from 'typeorm';
 import {
   IsOptional,
   IsString,
@@ -15,6 +15,7 @@ import { BaseEntity } from '../base-entity';
 import { UserProfile } from '../users-profiles/user-profile.entity';
 import { Company } from '../companies/company.entity';
 import { Project } from '../projects/project.entity';
+import { UserProject } from '../projects/userProject.entity';
 
 const { CREATE, UPDATE } = CrudValidationGroups;
 
@@ -57,4 +58,7 @@ export class User extends BaseEntity {
 
   @ManyToMany((type) => Project, (c) => c.users)
   projects?: Project[];
+
+  @OneToMany((type) => UserProject, (el) => el.user, { persistence: false, onDelete: 'CASCADE' })
+  userProjects!: UserProject[];
 }

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -7,7 +7,12 @@ import {
   JoinOptions,
   QueryOptions,
 } from '@nestjsx/crud';
-import { ParsedRequestParams, QueryFilter, QueryJoin, QuerySort } from '@nestjsx/crud-request';
+import {
+  ParsedRequestParams,
+  QueryFilter,
+  QueryJoin,
+  QuerySort,
+} from '@nestjsx/crud-request';
 import { hasLength, isArrayFull, isObject, isUndefined, objKeys } from '@nestjsx/util';
 import { plainToClass } from 'class-transformer';
 import { ClassType } from 'class-transformer/ClassTransformer';
@@ -341,8 +346,8 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
           type: this.getJoinType(curr.relationType),
           columns: curr.inverseEntityMetadata.columns.map((col) => col.propertyName),
           referencedColumn: (curr.joinColumns.length
-              ? curr.joinColumns[0]
-              : curr.inverseRelation.joinColumns[0]
+            ? curr.joinColumns[0]
+            : curr.inverseRelation.joinColumns[0]
           ).referencedColumn.propertyName,
         },
       }),
@@ -430,17 +435,17 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
 
   private getAllowedColumns(columns: string[], options: QueryOptions): string[] {
     return (!options.exclude || !options.exclude.length) &&
-    (!options.allow || /* istanbul ignore next */ !options.allow.length)
+      (!options.allow || /* istanbul ignore next */ !options.allow.length)
       ? columns
       : columns.filter(
-        (column) =>
-          (options.exclude && options.exclude.length
-            ? !options.exclude.some((col) => col === column)
-            : /* istanbul ignore next */ true) &&
-          (options.allow && options.allow.length
-            ? options.allow.some((col) => col === column)
-            : /* istanbul ignore next */ true),
-      );
+          (column) =>
+            (options.exclude && options.exclude.length
+              ? !options.exclude.some((col) => col === column)
+              : /* istanbul ignore next */ true) &&
+            (options.allow && options.allow.length
+              ? options.allow.some((col) => col === column)
+              : /* istanbul ignore next */ true),
+        );
   }
 
   private getRelationMetadata(field: string) {
@@ -485,8 +490,8 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
         type: this.getJoinType(curr.relationType),
         columns: curr.inverseEntityMetadata.columns.map((col) => col.propertyName),
         referencedColumn: (curr.joinColumns.length
-            ? /* istanbul ignore next */ curr.joinColumns[0]
-            : curr.inverseRelation.joinColumns[0]
+          ? /* istanbul ignore next */ curr.joinColumns[0]
+          : curr.inverseRelation.joinColumns[0]
         ).referencedColumn.propertyName,
         nestedRelation: curr.nestedRelation,
       };
@@ -509,15 +514,20 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
           : cond.select.filter((col) => allowed.some((a) => a === col));
 
       const select = [
-        relation.referencedColumn,
         ...(options.persist && options.persist.length ? options.persist : []),
         ...columns,
-      ].map((col) => `${relation.name}.${col}`);
+      ];
+
+      // When there is not any allowed columns,
+      // we add the referencedColumn to the select
+      if (columns.length === 0) {
+        select.push(relation.referencedColumn);
+      }
 
       const relationPath = relation.nestedRelation || `${this.alias}.${relation.name}`;
 
       builder[relation.type](relationPath, relation.name);
-      builder.addSelect(select);
+      builder.addSelect(select.map((col) => `${relation.name}.${col}`));
     }
 
     return true;
@@ -556,8 +566,8 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     return query.page && take
       ? take * (query.page - 1)
       : query.offset
-        ? query.offset
-        : null;
+      ? query.offset
+      : null;
   }
 
   private getTake(query: ParsedRequestParams, options: QueryOptions): number | null {
@@ -584,8 +594,8 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     return query.sort && query.sort.length
       ? this.mapSort(query.sort)
       : options.sort && options.sort.length
-        ? this.mapSort(options.sort)
-        : {};
+      ? this.mapSort(options.sort)
+      : {};
   }
 
   private getFieldWithAlias(field: string) {

--- a/packages/crud-typeorm/test/0.basic-crud.spec.ts
+++ b/packages/crud-typeorm/test/0.basic-crud.spec.ts
@@ -28,8 +28,7 @@ describe('#crud-typeorm', () => {
     })
     @Controller('companies')
     class CompaniesController {
-      constructor(public service: CompaniesService) {
-      }
+      constructor(public service: CompaniesService) {}
     }
 
     @Crud({
@@ -60,8 +59,7 @@ describe('#crud-typeorm', () => {
     })
     @Controller('companies/:companyId/users')
     class UsersController {
-      constructor(public service: UsersService) {
-      }
+      constructor(public service: UsersService) {}
     }
 
     beforeAll(async () => {
@@ -240,6 +238,7 @@ describe('#crud-typeorm', () => {
           profile: {
             name: 'testName',
           },
+          userProjects: [],
         };
         return request(server)
           .post('/companies/1/users')

--- a/packages/crud-typeorm/test/1.query-params.spec.ts
+++ b/packages/crud-typeorm/test/1.query-params.spec.ts
@@ -51,6 +51,8 @@ describe('#crud-typeorm', () => {
             persist: ['id'],
             exclude: ['updatedAt', 'createdAt'],
           },
+          users: {},
+          userProjects: {},
         },
         sort: [{ field: 'id', order: 'ASC' }],
         limit: 100,
@@ -261,6 +263,26 @@ describe('#crud-typeorm', () => {
             expect(res.status).toBe(200);
             expect(res.body.users).toBeDefined();
             expect(res.body.users.length).not.toBe(0);
+            done();
+          });
+      });
+
+      it('should return joined entity, 3', (done) => {
+        const query = qb
+          .setJoin({ field: 'users' })
+          .setJoin({ field: 'userProjects' })
+          .query();
+        return request(server)
+          .get('/projects/1')
+          .query(query)
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.users).toBeDefined();
+            expect(res.body.users.length).toBe(2);
+            expect(res.body.users[0].id).toBe(1);
+            expect(res.body.userProjects).toBeDefined();
+            expect(res.body.userProjects.length).toBe(2);
+            expect(res.body.userProjects[0].review).toBe('User project 1 1');
             done();
           });
       });


### PR DESCRIPTION
The `relation.referencedColumn` in `packages/crud-typeorm/src/typeorm-crud.service.ts:512` was always added which was causing an issue with pivot tables as they have no `id` columns.  

Now, the column is added when the `columns ` variable is empty because the join is selecting an unknown column. 