### PR TITLE
Fix override methods Swagger metadata

### DIFF
--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -230,12 +230,13 @@ export class CrudRoutesFactory {
         const interceptors = R.getInterceptors(this.targetProto[name]);
         const baseInterceptors = R.getInterceptors(this.targetProto[override]);
         const baseAction = R.getAction(this.targetProto[override]);
+        const baseOperation = Swagger.getOperation(this.targetProto[override]);
         const baseSwaggerParams = Swagger.getParams(this.targetProto[override]);
         const baseResponseOk = Swagger.getResponseOk(this.targetProto[override]);
         // set metadata
         R.setInterceptors([...baseInterceptors, ...interceptors], this.targetProto[name]);
         R.setAction(baseAction, this.targetProto[name]);
-        Swagger.setOperation(override, this.modelName, this.targetProto[name]);
+        Swagger.setOperation(baseOperation, this.targetProto[name]);
         Swagger.setParams(baseSwaggerParams, this.targetProto[name]);
         Swagger.setResponseOk(baseResponseOk, this.targetProto[name]);
         this.overrideParsedBodyDecorator(override, name);
@@ -380,7 +381,8 @@ export class CrudRoutesFactory {
   }
 
   private setSwaggerOperation(name: BaseRouteName) {
-    Swagger.setOperation(name, this.modelName, this.targetProto[name]);
+    const summary = Swagger.operationsMap(this.modelName)[name];
+    Swagger.setOperation({ summary }, this.targetProto[name]);
   }
 
   private setSwaggerPathParams(name: BaseRouteName) {

--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -230,15 +230,24 @@ export class CrudRoutesFactory {
         const interceptors = R.getInterceptors(this.targetProto[name]);
         const baseInterceptors = R.getInterceptors(this.targetProto[override]);
         const baseAction = R.getAction(this.targetProto[override]);
+        const operation = Swagger.getOperation(this.targetProto[name]);
         const baseOperation = Swagger.getOperation(this.targetProto[override]);
+        const swaggerParams = Swagger.getParams(this.targetProto[name]);
         const baseSwaggerParams = Swagger.getParams(this.targetProto[override]);
+        const responseOk = Swagger.getResponseOk(this.targetProto[name]);
         const baseResponseOk = Swagger.getResponseOk(this.targetProto[override]);
         // set metadata
         R.setInterceptors([...baseInterceptors, ...interceptors], this.targetProto[name]);
         R.setAction(baseAction, this.targetProto[name]);
-        Swagger.setOperation(baseOperation, this.targetProto[name]);
-        Swagger.setParams(baseSwaggerParams, this.targetProto[name]);
-        Swagger.setResponseOk(baseResponseOk, this.targetProto[name]);
+        Swagger.setOperation({ ...baseOperation, ...operation }, this.targetProto[name]);
+        Swagger.setParams(
+          [...baseSwaggerParams, ...swaggerParams],
+          this.targetProto[name],
+        );
+        Swagger.setResponseOk(
+          { ...baseResponseOk, ...responseOk },
+          this.targetProto[name],
+        );
         this.overrideParsedBodyDecorator(override, name);
         // enable route
         R.setRoute(route, this.targetProto[name]);

--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -22,11 +22,10 @@ export class Swagger {
     };
   }
 
-  static setOperation(name: BaseRouteName, modelName: string, func: Function) {
+  static setOperation(metadata: any, func: Function) {
     /* istanbul ignore else */
     if (swaggerPkg) {
-      const summary = Swagger.operationsMap(modelName)[name];
-      R.set(swaggerPkg.DECORATORS.API_OPERATION, { summary }, func);
+      R.set(swaggerPkg.DECORATORS.API_OPERATION, metadata, func);
     }
   }
 


### PR DESCRIPTION
Hi everyone,

One more Swagger metadata fix :slightly_smiling_face:

This PR:
- Allows specifying ApiOperation Swagger meta on overridden methods in the decorators option;
   For example:
   ```typescript
   @Crud({
     routes: {
       getManyBase: {
         decorators: [
           ApiOperation({
             title: 'Get list of something',
             operationId: 'getSomething',
           }),
         ],
       },
     },
   })
   export class SomeController {}
   ```
- Takes into account Swagger meta defined on overridden methods.
   For example, allow specifying Swagger metadata this way:
   ```typescript
   export class SomeController {
     @Override()
     @ApiOperation({
       title: 'Get list of something',
       operationId: 'getSomething',
     }),
     @ApiOkResponse({ type: Something })
     public getMany() {}
   }
   ```