### PR TITLE
fix(crud-request): Query bigints should remain a string

### DIFF
--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -180,6 +180,12 @@ export class RequestQueryParser implements ParsedRequestParams {
       if (!isDate(parsed) && isObject(parsed)) {
         // throw new Error('Don\'t support object now');
         return val;
+      } else if (
+        typeof parsed === 'number' &&
+        parsed.toLocaleString('fullwide', { useGrouping: false }) !== val
+      ) {
+        // JS cannot handle big numbers. Leave it as a string to prevent data loss
+        return val;
       }
 
       return parsed;

--- a/packages/crud-request/test/request-query.parser.spec.ts
+++ b/packages/crud-request/test/request-query.parser.spec.ts
@@ -143,6 +143,14 @@ describe('#request-query', () => {
           const test = qp.parseQuery(query);
           expect(test.filter[0]).toMatchObject(expected[0]);
         });
+        it('should set string, 11', () => {
+          const query = { filter: ['foo||eq||4202140192612927005304000000236630'] };
+          const expected: QueryFilter[] = [
+            { field: 'foo', operator: 'eq', value: '4202140192612927005304000000236630' },
+          ];
+          const test = qp.parseQuery(query);
+          expect(test.filter[0]).toMatchObject(expected[0]);
+        });
       });
 
       describe('#parse or', () => {


### PR DESCRIPTION
JS cannot handle big numbers, during `JSON.parse` big number will be truncated and causes data loss. In order to prevent the data loss, leave the big number as a string if the string representation is not equals the original input. 