### PR TITLE
fix(crud-request): small fix on type SFields definition

### DIFF
--- a/packages/crud-request/src/types/request-query.types.ts
+++ b/packages/crud-request/src/types/request-query.types.ts
@@ -84,7 +84,7 @@ export type SFieldOperator = {
 export type SField = SPrimitivesVal | SFieldOperator;
 
 export type SFields = {
-  [key: string]: SField | Array<SFields | SConditionAND>;
+  [key: string]: SField | Array<SFields | SConditionAND> | undefined;
   $or?: Array<SFields | SConditionAND>;
   $and?: never;
 };


### PR DESCRIPTION
Small fix on type SFields definition to make strict=true typescript projects builds work.

```
node_modules/@nestjsx/crud-request/lib/types/request-query.types.d.ts:61:5 - error TS2411: Property '$or' of type '(SFields | SConditionAND)[] | undefined' is not assignable to string index type 'string | number | boolean | SFieldOperator | (SFields | SConditionAND)[]'.

61     $or?: Array<SFields | SConditionAND>;
       ~~~

node_modules/@nestjsx/crud-request/lib/types/request-query.types.d.ts:62:5 - error TS2411: Property '$and' of type 'undefined' is not assignable to string index type 'string | number | boolean | SFieldOperator | (SFields | SConditionAND)[]'.

62     $and?: never;
       ~~~~


Found 2 errors.
```