### PR TITLE
Serialize option in global config

### DIFF
--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -107,9 +107,8 @@ export class CrudRoutesFactory {
     }
 
     // set serialize
-    if (!isObjectFull(this.options.serialize)) {
-      this.options.serialize = {};
-    }
+    const serialize = isObjectFull(this.options.serialize) ? this.options.serialize : {};
+    this.options.serialize = { ...CrudConfigService.config.serialize, ...serialize };
     this.options.serialize.get = isFalse(this.options.serialize.get)
       ? false
       : this.options.serialize.get || this.modelType;

--- a/packages/crud/src/interfaces/crud-global-config.interface.ts
+++ b/packages/crud/src/interfaces/crud-global-config.interface.ts
@@ -15,4 +15,13 @@ export interface CrudGlobalConfig {
     cache?: number | false;
     alwaysPaginate?: boolean;
   };
+  serialize?: {
+    getMany?: false;
+    get?: false;
+    create?: false;
+    createMany?: false;
+    update?: false;
+    replace?: false;
+    delete?: false;
+  };
 }

--- a/packages/crud/src/module/crud-config.service.ts
+++ b/packages/crud/src/module/crud-config.service.ts
@@ -41,10 +41,11 @@ export class CrudConfigService {
     const query = isObjectFull(config.query) ? config.query : {};
     const routes = isObjectFull(config.routes) ? config.routes : {};
     const params = isObjectFull(config.params) ? config.params : {};
+    const serialize = isObjectFull(config.serialize) ? config.serialize : {};
 
     CrudConfigService.config = deepmerge(
       CrudConfigService.config,
-      { auth, query, routes, params },
+      { auth, query, routes, params, serialize },
       { arrayMerge: (a, b, c) => b },
     );
   }

--- a/packages/crud/test/crud-config.service.global.spec.ts
+++ b/packages/crud/test/crud-config.service.global.spec.ts
@@ -29,6 +29,9 @@ const conf: CrudGlobalConfig = {
       allowParamsOverride: true,
     },
   },
+  serialize: {
+    get: false,
+  },
 };
 
 // Important: load config before (!!!) you import AppModule


### PR DESCRIPTION
Using `class-transformer` with Sequelize classes results in a `Maximum call stack size exceeded` error so instead of marking every class with `serialize: { get: false }` in the `@Crud` options I added it to the `GlobalConfigService` to be set as `false` globally.