### PR TITLE
fix(crud): missing types on query params sort filter join swagger 3.1.0

### DIFF
--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -278,6 +278,7 @@ export class Swagger {
           items: {
             type: 'string',
           },
+          type: 'array',
           collectionFormat: 'multi',
         }
       : {
@@ -304,6 +305,7 @@ export class Swagger {
           items: {
             type: 'string',
           },
+          type: 'array',
           collectionFormat: 'multi',
         }
       : {
@@ -330,6 +332,7 @@ export class Swagger {
           items: {
             type: 'string',
           },
+          type: 'array',
           collectionFormat: 'multi',
         }
       : {
@@ -356,6 +359,7 @@ export class Swagger {
           items: {
             type: 'string',
           },
+          type: 'array',
           collectionFormat: 'multi',
         }
       : {


### PR DESCRIPTION
This Pull Request fixes an issue with `@nestjs/swagger` where it was generating `type: ''` for filter, sort, or, and join query params - thus creating an invalid Swagger file. 

We only tested this with @nestjs/swagger 3.1.0.

![swagger-empty-type](https://user-images.githubusercontent.com/1887572/72799166-81b44200-3c3c-11ea-86bd-d3711e532811.png)
![swagger-empty-type-errors](https://user-images.githubusercontent.com/1887572/72799170-84169c00-3c3c-11ea-9ec5-75fbe032bd69.png)
