### PR TITLE
Bugfix: filter conditions missing the sql LOWER() function

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -895,22 +895,22 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
         break;
 
       case '$startsL':
-        str = `${field} ${likeOperator} :${param}`;
+        str = `LOWER(${field}) ${likeOperator} :${param}`;
         params = { [param]: `${cond.value}%` };
         break;
 
       case '$endsL':
-        str = `${field} ${likeOperator} :${param}`;
+        str = `LOWER(${field}) ${likeOperator} :${param}`;
         params = { [param]: `%${cond.value}` };
         break;
 
       case '$contL':
-        str = `${field} ${likeOperator} :${param}`;
+        str = `LOWER(${field}) ${likeOperator} :${param}`;
         params = { [param]: `%${cond.value}%` };
         break;
 
       case '$exclL':
-        str = `${field} NOT ${likeOperator} :${param}`;
+        str = `LOWER(${field}) NOT ${likeOperator} :${param}`;
         params = { [param]: `%${cond.value}%` };
         break;
 


### PR DESCRIPTION
The filter conditions $startL, $endsL, $contL, $excl where missing the sql LOWER() function to work correctly.

The fix was tested on an oracle DB. Now the SQL queries are executed correctly.