### PR TITLE
fix(crud): merge crud options from methods and classes

### DIFF
--- a/packages/crud/src/interceptors/crud-base.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-base.interceptor.ts
@@ -14,13 +14,12 @@ export class CrudBaseInterceptor {
     const ctrl = context.getClass();
     const handler = context.getHandler();
     const ctrlOptions = R.getCrudOptions(ctrl);
-    const crudOptions = ctrlOptions
-      ? ctrlOptions
-      : {
-          query: {},
-          routes: {},
-          params: {},
-        };
+    const methodOptions = R.getCrudOptions(handler);
+    const { query: methodQuery, params: methodParams } = { ...methodOptions };
+    const { query: ctrlQuery, params: ctrlParams, ...ctrlOthers } = { ...ctrlOptions };
+    const query = { ...ctrlQuery, ...methodQuery };
+    const params = { ...ctrlParams, ...methodParams };
+    const crudOptions = { query, params, routes: {}, ...ctrlOthers };
     const action = R.getAction(handler);
 
     return { ctrlOptions, crudOptions, action };

--- a/packages/crud/src/interfaces/crud-options.interface.ts
+++ b/packages/crud/src/interfaces/crud-options.interface.ts
@@ -1,11 +1,11 @@
 import { ValidationPipeOptions } from '@nestjs/common';
+import { AuthOptions } from './auth-options.interface';
+import { DtoOptions } from './dto-options.interface';
 
 import { ModelOptions } from './model-options.interface';
 import { ParamsOptions } from './params-options.interface';
 import { QueryOptions } from './query-options.interface';
 import { RoutesOptions } from './routes-options.interface';
-import { AuthOptions } from './auth-options.interface';
-import { DtoOptions } from './dto-options.interface';
 import { SerializeOptions } from './serialize-options.interface';
 
 export interface CrudRequestOptions {
@@ -14,13 +14,10 @@ export interface CrudRequestOptions {
   params?: ParamsOptions;
 }
 
-export interface CrudOptions {
+export interface CrudOptions extends CrudRequestOptions {
   model: ModelOptions;
   dto?: DtoOptions;
   serialize?: SerializeOptions;
-  query?: QueryOptions;
-  routes?: RoutesOptions;
-  params?: ParamsOptions;
   validation?: ValidationPipeOptions | false;
 }
 


### PR DESCRIPTION
Since `CrudRequestInterceptor` can be used detached, there is a problem about the incoming query and the static built-in query. Every methods which use  `CrudRequestInterceptor` out of `crud` can have a options by their own. The `search` option solved the problem about query merge. But comes a new one that the `filter` set after `req` created does not take effect. So put this `options` in method's metadata and `CrudRequestInterceptor` gets from it before `req` created to make it work.

use `SetMetadata(CRUD_OPTIONS_METADATA, { query, params })` in my custom decorators and  `CrudRequestInterceptor` will get this from method.