### PR TITLE
Fix(crud): Do not return pageCount on getMany in some cases

### DIFF
--- a/packages/crud/src/services/crud-service.abstract.ts
+++ b/packages/crud/src/services/crud-service.abstract.ts
@@ -52,12 +52,8 @@ export abstract class CrudService<T> {
       data,
       count: data.length,
       total,
-      page: Math.floor(offset / limit) + 1,
-      pageCount:
-        limit && total
-          ? Math.ceil(total / limit)
-          : /* istanbul ignore next line */
-            undefined,
+      page: limit ? Math.floor(offset / limit) + 1 : 1,
+      pageCount: limit && total ? Math.ceil(total / limit) : 1,
     };
   }
 

--- a/packages/crud/src/types/query-filter-option.type.ts
+++ b/packages/crud/src/types/query-filter-option.type.ts
@@ -1,7 +1,7 @@
 import {
   QueryFilter,
   SCondition,
-} from '@nestjsx/crud-request/lib/types/request-query.types';
+} from '@nestjsx/crud-request/src/types/request-query.types';
 
 export type QueryFilterFunction = (
   search?: SCondition,

--- a/packages/crud/test/__fixture__/services/test.service.ts
+++ b/packages/crud/test/__fixture__/services/test.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ParsedRequestParams } from '@nestjsx/crud-request';
-import { CrudRequestOptions } from '../../../lib/interfaces';
+import { CrudRequestOptions } from '../../../src/interfaces';
 
 import { CreateManyDto, CrudRequest } from '../../../src/interfaces';
 import { CrudService } from '../../../src/services';

--- a/packages/crud/test/crud-service.abstract.spec.ts
+++ b/packages/crud/test/crud-service.abstract.spec.ts
@@ -37,6 +37,19 @@ describe('#crud', () => {
         };
         expect(service.createPageInfo([], 100, 10, 10)).toMatchObject(expected);
       });
+
+      it('should return an object when limit and offset undefined', () => {
+        const expected = {
+          count: 0,
+          data: [],
+          page: 1,
+          pageCount: 1,
+          total: 100,
+        };
+        expect(service.createPageInfo([], 100, undefined, undefined)).toMatchObject(
+          expected,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
When alwaysPaginate mode enabled and no limit parameter in request it skip pageCount field in response. But this parameter is marked as required in the generated schema. This results in an error validating the response.