### PR TITLE
feat(crud): Add enum support to @Crud params

### DIFF
--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -488,7 +488,7 @@ export class CrudRoutesFactory {
           {},
         )
       : this.options.params;
-    const pathParamsMeta = Swagger.createPathParasmMeta(params);
+    const pathParamsMeta = Swagger.createPathParamsMeta(params);
     Swagger.setParams([...metadata, ...pathParamsMeta], this.targetProto[name]);
   }
 

--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -212,13 +212,14 @@ export class Swagger {
     }
   }
 
-  static createPathParasmMeta(options: ParamsOptions): any[] {
+  static createPathParamsMeta(options: ParamsOptions): any[] {
     return swaggerConst
       ? objKeys(options).map((param) => ({
           name: param,
           required: true,
           in: 'path',
           type: options[param].type === 'number' ? Number : String,
+          enum: options[param].enum ? Object.values(options[param].enum) : undefined,
         }))
       : /* istanbul ignore next */ [];
   }

--- a/packages/crud/src/interfaces/params-options.interface.ts
+++ b/packages/crud/src/interfaces/params-options.interface.ts
@@ -1,3 +1,4 @@
+import { SwaggerEnumType } from '@nestjs/swagger/dist/types/swagger-enum.type';
 import { ParamOptionType } from '@nestjsx/crud-request';
 
 export interface ParamsOptions {
@@ -7,6 +8,7 @@ export interface ParamsOptions {
 export interface ParamOption {
   field?: string;
   type?: ParamOptionType;
+  enum?: SwaggerEnumType;
   primary?: boolean;
   disabled?: boolean;
 }

--- a/packages/crud/test/crud.decorator.override.spec.ts
+++ b/packages/crud/test/crud.decorator.override.spec.ts
@@ -18,8 +18,19 @@ describe('#crud', () => {
     let server: any;
     let qb: RequestQueryBuilder;
 
+    enum Field {
+      ONE = 'one',
+    }
+
     @Crud({
       model: { type: TestModel },
+      params: {
+        enumField: {
+          field: 'enum_field',
+          type: 'string',
+          enum: Field,
+        },
+      },
     })
     @Controller('test')
     class TestController implements CrudController<TestModel> {
@@ -99,6 +110,10 @@ describe('#crud', () => {
         const params = Swagger.getParams(TestController.prototype.getMany);
         expect(Array.isArray(params)).toBe(true);
         expect(params.length > 0).toBe(true);
+
+        const enumParam = params.find((param) => param.name === 'enumField');
+        expect(enumParam).toBeDefined();
+        expect(enumParam.enum).toEqual(['one']);
       });
       it('should return swagger response ok', () => {
         const response = Swagger.getResponseOk(TestController.prototype.getMany);


### PR DESCRIPTION
```
enum Company {
  ELECTRIC = 'electric',
  WATER = 'water'
}
@Crud({
  model: {
    type: CompanyEntity
  },
  params: {
    companyId: {
      field: 'company',
      type: 'string',
      enum: Company,
    }
  }
})
```

Similar to `@ApiParam({ name: 'companyId', enum: Company })`