### PR TITLE
Fix(crud-response-interceptor): classToPlain call two times

### DIFF
--- a/packages/crud/src/interceptors/crud-response.interceptor.ts
+++ b/packages/crud/src/interceptors/crud-response.interceptor.ts
@@ -43,7 +43,7 @@ export class CrudResponseInterceptor extends CrudBaseInterceptor
 
     return data instanceof dto
       ? classToPlain(data)
-      : classToPlain(classToPlainFromExist(data, new dto()));
+      : classToPlainFromExist(data, new dto());
   }
 
   protected serialize(context: ExecutionContext, data: any): any {

--- a/packages/crud/test/__fixture__/models/index.ts
+++ b/packages/crud/test/__fixture__/models/index.ts
@@ -1,3 +1,4 @@
 export * from './test.model';
 export * from './test-serialize.model';
 export * from './test-serialize-2.model';
+export * from './test-serialize.transform';

--- a/packages/crud/test/__fixture__/models/test-serialize.transform.ts
+++ b/packages/crud/test/__fixture__/models/test-serialize.transform.ts
@@ -1,0 +1,25 @@
+import { Exclude, Transform } from 'class-transformer';
+
+import { TestSerializeModel } from './test-serialize.model';
+
+export class TestSerializeTransformModel extends TestSerializeModel {
+  
+  id: number;
+
+  @Transform((value, obj) => {
+    // throw new Error('HA')
+    //console.log(obj)
+    return obj.id + ':' + obj.name;
+  })
+  name: string;
+  
+  email: string;
+
+  @Exclude()
+  isActive: boolean;
+
+  constructor(partial: Partial<TestSerializeTransformModel>) {
+    super(partial);
+    Object.assign(this, partial);
+  }
+}

--- a/packages/crud/test/__fixture__/models/test-serialize.transform.ts
+++ b/packages/crud/test/__fixture__/models/test-serialize.transform.ts
@@ -3,16 +3,11 @@ import { Exclude, Transform } from 'class-transformer';
 import { TestSerializeModel } from './test-serialize.model';
 
 export class TestSerializeTransformModel extends TestSerializeModel {
-  
   id: number;
 
-  @Transform((value, obj) => {
-    // throw new Error('HA')
-    //console.log(obj)
-    return obj.id + ':' + obj.name;
-  })
+  @Transform((value, obj) => obj.id + ':' + obj.name)
   name: string;
-  
+
   email: string;
 
   @Exclude()

--- a/packages/crud/test/crud.transform.spec.ts
+++ b/packages/crud/test/crud.transform.spec.ts
@@ -9,12 +9,11 @@ import { TestSerializeModel, TestSerializeTransformModel } from './__fixture__/m
 
 import { TestSerializeService } from './__fixture__/services';
 
-
 describe('#crud', () => {
   describe('#transform', () => {
     let app: INestApplication;
     let server: any;
-   
+
     const SERVICE = 'TestSerializeService';
 
     @Crud({
@@ -29,17 +28,15 @@ describe('#crud', () => {
     class TestController {
       constructor(@Inject(SERVICE) public service: TestSerializeService) {}
     }
-    
+
     beforeAll(async () => {
       const fixture = await Test.createTestingModule({
-        controllers: [
-          TestController
-        ],
+        controllers: [TestController],
         providers: [
           {
             provide: SERVICE,
             useFactory: () => new TestSerializeService(TestSerializeModel),
-          }
+          },
         ],
       }).compile();
 
@@ -64,6 +61,5 @@ describe('#crud', () => {
           });
       });
     });
-
   });
 });

--- a/packages/crud/test/crud.transform.spec.ts
+++ b/packages/crud/test/crud.transform.spec.ts
@@ -1,0 +1,69 @@
+import * as request from 'supertest';
+import { Test } from '@nestjs/testing';
+import { Controller, INestApplication, Inject } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+
+import { Crud } from '../src/decorators';
+import { HttpExceptionFilter } from './__fixture__/exception.filter';
+import { TestSerializeModel, TestSerializeTransformModel } from './__fixture__/models';
+
+import { TestSerializeService } from './__fixture__/services';
+
+
+describe('#crud', () => {
+  describe('#transform', () => {
+    let app: INestApplication;
+    let server: any;
+   
+    const SERVICE = 'TestSerializeService';
+
+    @Crud({
+      model: {
+        type: TestSerializeTransformModel,
+      },
+      query: {
+        alwaysPaginate: true,
+      },
+    })
+    @Controller('test')
+    class TestController {
+      constructor(@Inject(SERVICE) public service: TestSerializeService) {}
+    }
+    
+    beforeAll(async () => {
+      const fixture = await Test.createTestingModule({
+        controllers: [
+          TestController
+        ],
+        providers: [
+          {
+            provide: SERVICE,
+            useFactory: () => new TestSerializeService(TestSerializeModel),
+          }
+        ],
+      }).compile();
+
+      app = fixture.createNestApplication();
+
+      await app.init();
+      server = app.getHttpServer();
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    describe('#transform', () => {
+      it('transform only one times', (done) => {
+        return request(server)
+          .get('/test')
+          .expect(200)
+          .end((_, res) => {
+            expect(res.body.data[0].name).toBe('1:name');
+            done();
+          });
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
https://github.com/nestjsx/crud/issues/525

@Transform in DTO called two times, this occurring only with alwaysPaginate set true

`@Transform((value, obj) => obj.F2 + ':' + obj.F2)`

DATA: 
`
{
"F1":1,
"F2":"YaEvwfvzVi"
}
`

Server response:
`
{
"data":[
{
"F1":1,
"F2":"YaEvwfvzVi:1:1"
}
],
"count":1,
"total":1000,
"page":1,
"pageCount":1000
}
`

`test_controller.ts`
```
@Crud({
  model: {
    type: TestDataDto
  },
  query: {
    alwaysPaginate: true,
  }
})
@Controller('test')
export class TestController implements CrudController<TestData>{
  constructor(public service: TestService){}
}
```

`test_service.ts`
```
@Injectable()
export class TestService extends TypeOrmCrudService<TestData>{
  constructor(@InjectRepository(TestData) usersRepository: Repository<TestData>){
    super(usersRepository);
  }
}
```
`test_entity.ts`
```
@Entity({ name: 'TEST_DATA' })
export class TestData {
  @PrimaryColumn()
  public F1: number;

  @Column()
  public F2: string;
}
```

`test_dto.ts`

```
@Exclude()
export class TestDataDto {
  @Expose()
  public F1: string;

  @Expose()
  @Transform((value, obj) => obj.F2 + ':' + obj.F1)
  public F2: string;
}
```
