### PR TITLE
feat: composite primary key

### DIFF
--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -127,13 +127,19 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     if (returnShallow) {
       return saved;
     } else {
-      const primaryParam = this.getPrimaryParam(req.options);
+      const primaryParams = this.getPrimaryParams(req.options);
 
       /* istanbul ignore if */
-      if (!primaryParam && /* istanbul ignore next */ isNil(saved[primaryParam])) {
+      if (
+        !primaryParams.length &&
+        /* istanbul ignore next */ primaryParams.some((p) => isNil(saved[p]))
+      ) {
         return saved;
       } else {
-        req.parsed.search = { [primaryParam]: saved[primaryParam] };
+        req.parsed.search = primaryParams.reduce(
+          (acc, p) => ({ ...acc, [p]: saved[p] }),
+          {},
+        );
         return this.getOneOrFail(req);
       }
     }
@@ -212,14 +218,17 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     if (returnShallow) {
       return replaced;
     } else {
-      const primaryParam = this.getPrimaryParam(req.options);
+      const primaryParams = this.getPrimaryParams(req.options);
 
       /* istanbul ignore if */
-      if (!primaryParam) {
+      if (!primaryParams.length) {
         return replaced;
       }
 
-      req.parsed.search = { [primaryParam]: replaced[primaryParam] };
+      req.parsed.search = primaryParams.reduce(
+        (acc, p) => ({ ...acc, [p]: replaced[p] }),
+        {},
+      );
       return this.getOneOrFail(req);
     }
   }

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -129,11 +129,8 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
     } else {
       const primaryParams = this.getPrimaryParams(req.options);
 
-      /* istanbul ignore if */
-      if (
-        !primaryParams.length &&
-        /* istanbul ignore next */ primaryParams.some((p) => isNil(saved[p]))
-      ) {
+      /* istanbul ignore next */
+      if (!primaryParams.length && primaryParams.some((p) => isNil(saved[p]))) {
         return saved;
       } else {
         req.parsed.search = primaryParams.reduce(

--- a/packages/crud-typeorm/test/c.basic-crud.spec.ts
+++ b/packages/crud-typeorm/test/c.basic-crud.spec.ts
@@ -238,6 +238,18 @@ describe('#crud-typeorm', () => {
     }
 
     @Crud({
+      model: { type: User },
+      params: {
+        companyId: { field: 'companyId', type: 'number', primary: true },
+        profileId: { field: 'profileId', type: 'number', primary: true },
+      },
+    })
+    @Controller('users4')
+    class UsersController4 {
+      constructor(public service: UsersService) {}
+    }
+
+    @Crud({
       model: { type: Device },
       params: {
         deviceKey: {
@@ -268,6 +280,7 @@ describe('#crud-typeorm', () => {
           UsersController,
           UsersController2,
           UsersController3,
+          UsersController4,
           DevicesController,
         ],
         providers: [
@@ -403,6 +416,15 @@ describe('#crud-typeorm', () => {
             expect(res.status).toBe(200);
             expect(res.body.id).toBe(1);
             expect(res.body.domain).toBeTruthy();
+            done();
+          });
+      });
+      it('should return an entity with compound key', (done) => {
+        return request(server)
+          .get('/users4/1/5')
+          .end((_, res) => {
+            expect(res.status).toBe(200);
+            expect(res.body.id).toBe(5);
             done();
           });
       });

--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -94,7 +94,7 @@ export class CrudRoutesFactory {
       : isObjectFull(CrudConfigService.config.params)
       ? CrudConfigService.config.params
       : {};
-    const hasPrimary = this.getPrimaryParam();
+    const hasPrimary = this.getPrimaryParams().length > 0;
     if (!hasPrimary) {
       this.options.params['id'] = {
         field: 'id',
@@ -283,7 +283,9 @@ export class CrudRoutesFactory {
   }
 
   private createRoutes(routesSchema: BaseRoute[]) {
-    const primaryParam = this.getPrimaryParam();
+    const primaryParams = this.getPrimaryParams().filter(
+      (param) => !this.options.params[param].disabled,
+    );
 
     routesSchema.forEach((route) => {
       if (this.canCreateRoute(route.name)) {
@@ -294,8 +296,8 @@ export class CrudRoutesFactory {
         this.setBaseRouteMeta(route.name);
       }
 
-      if (route.withParams && !this.options.params[primaryParam].disabled) {
-        route.path = `/:${primaryParam}`;
+      if (route.withParams && primaryParams.length > 0) {
+        route.path = primaryParams.map((param) => `/:${param}`).join('');
       }
     });
   }
@@ -391,8 +393,8 @@ export class CrudRoutesFactory {
     }
   }
 
-  private getPrimaryParam(): string {
-    return objKeys(this.options.params).find(
+  private getPrimaryParams(): string[] {
+    return objKeys(this.options.params).filter(
       (param) => this.options.params[param] && this.options.params[param].primary,
     );
   }

--- a/packages/crud/src/services/crud-service.abstract.ts
+++ b/packages/crud/src/services/crud-service.abstract.ts
@@ -112,16 +112,11 @@ export abstract class CrudService<T> {
    * Get primary param name from CrudOptions
    * @param options
    */
-  getPrimaryParam(options: CrudRequestOptions): string {
-    const param = objKeys(options.params).find(
+  getPrimaryParams(options: CrudRequestOptions): string[] {
+    const params = objKeys(options.params).filter(
       (n) => options.params[n] && options.params[n].primary,
     );
 
-    /* istanbul ignore if */
-    if (!param) {
-      return undefined;
-    }
-
-    return options.params[param].field;
+    return params.map((p) => options.params[p].field);
   }
 }

--- a/packages/crud/test/crud-request.interceptor.spec.ts
+++ b/packages/crud/test/crud-request.interceptor.spec.ts
@@ -111,13 +111,31 @@ describe('#crud', () => {
     }
   }
 
+  @Crud({
+    model: { type: TestModel },
+    params: {
+      someParam: { field: 'someParam', type: 'number', primary: true },
+      someParam2: { field: 'someParam2', type: 'number', primary: true },
+    },
+  })
+  @Controller('test5')
+  class Test5Controller {
+    constructor(public service: TestService<TestModel>) {}
+  }
+
   let $: supertest.SuperTest<supertest.Test>;
   let app: NestApplication;
 
   beforeAll(async () => {
     const module = await Test.createTestingModule({
       providers: [TestService],
-      controllers: [TestController, Test2Controller, Test3Controller, Test4Controller],
+      controllers: [
+        TestController,
+        Test2Controller,
+        Test3Controller,
+        Test4Controller,
+        Test5Controller,
+      ],
     }).compile();
     app = module.createNestApplication();
     await app.init();
@@ -193,6 +211,10 @@ describe('#crud', () => {
       expect(res.body.filter).toHaveLength(2);
       expect(res.body.filter[0].field).toBe('id');
       expect(res.body.filter[0].value).toBe(1);
+    });
+
+    it('should parse multiple primary key', async () => {
+      const res = await $.get('/test5/123/456').expect(200);
     });
 
     it('should work like before', async () => {


### PR DESCRIPTION
fix https://github.com/nestjsx/crud/issues/164
add the possibility to have multiple primary keys.

exemple:
``` typescript
@Crud({
  ...
  params: {
    ...
    companyId: {
      field: 'companyId',
      type: 'number',
      primary: true
    },
    userId: {
      field: 'userId',
      type: 'number',
      primary: true
    },
  },
  ...
})
@Controller("teams")
export class TeamController {
  constructor(public service: TeamsService) {}
}
```
allow a team to be acceded from `teams/{companyId}/{userId}`