### PR TITLE
Allow all relation to be joined

### DIFF
--- a/packages/crud/src/interfaces/crud-global-config.interface.ts
+++ b/packages/crud/src/interfaces/crud-global-config.interface.ts
@@ -14,6 +14,7 @@ export interface CrudGlobalConfig {
     maxLimit?: number;
     cache?: number | false;
     alwaysPaginate?: boolean;
+    join?: boolean;
   };
   serialize?: {
     getMany?: false;

--- a/packages/crud/src/interfaces/query-options.interface.ts
+++ b/packages/crud/src/interfaces/query-options.interface.ts
@@ -10,7 +10,7 @@ export interface QueryOptions {
   exclude?: QueryFields;
   persist?: QueryFields;
   filter?: QueryFilterOption;
-  join?: JoinOptions;
+  join?: JoinOptions | boolean;
   sort?: QuerySort[];
   limit?: number;
   maxLimit?: number;

--- a/packages/crud/test/crud-config.service.global.spec.ts
+++ b/packages/crud/test/crud-config.service.global.spec.ts
@@ -12,6 +12,7 @@ import { CrudConfigService } from '../src/module/crud-config.service';
 const conf: CrudGlobalConfig = {
   query: {
     limit: 10,
+    join: true,
   },
   params: {
     id: {
@@ -60,6 +61,7 @@ describe('#crud', () => {
       model: { type: TestModel },
       query: {
         limit: 12,
+        join: false,
       },
       params: {
         id: {
@@ -114,6 +116,7 @@ describe('#crud', () => {
           expect(res.body.req.options.routes.replaceOneBase.allowParamsOverride).toBe(
             true,
           );
+          expect(res.body.req.options.query.join).toBe(true);
           done();
         });
     });
@@ -139,6 +142,7 @@ describe('#crud', () => {
             false,
           );
           expect(res.body.req.options.routes.deleteOneBase.returnDeleted).toBe(true);
+          expect(res.body.req.options.query.join).toBe(false);
           done();
         });
     });


### PR DESCRIPTION
Hi there,
I use this module internally and I usually have all relations "joinable" by default, meaning I don't have to specify the allowed joins in each controller (they are all allowed). So what I did here is I added the ability to set the join option to be a boolean so when it is set to `true` all relations are allowed and I added this options in the global config and it's `false` be default of course.