### PR TITLE
fix(crud-routes): remove disabled fields from swagger docs

### DIFF
--- a/packages/crud/src/crud/crud-routes.factory.ts
+++ b/packages/crud/src/crud/crud-routes.factory.ts
@@ -485,13 +485,13 @@ export class CrudRoutesFactory {
       'createOneBase',
       'getManyBase',
     ];
-    const params = isIn(name, withoutPrimary)
-      ? objKeys(this.options.params).reduce(
-          (a, c) =>
-            this.options.params[c].primary ? a : { ...a, [c]: this.options.params[c] },
-          {},
-        )
-      : this.options.params;
+
+    const removePrimary = isIn(name, withoutPrimary);
+    const params = objKeys(this.options.params)
+      .filter((key) => !this.options.params[key].disabled)
+      .filter((key) => !(removePrimary && this.options.params[key].primary))
+      .reduce((a, c) => ({ ...a, [c]: this.options.params[c] }), {});
+
     const pathParamsMeta = Swagger.createPathParamsMeta(params);
     Swagger.setParams([...metadata, ...pathParamsMeta], this.targetProto[name]);
   }

--- a/packages/crud/test/crud.decorator.override.spec.ts
+++ b/packages/crud/test/crud.decorator.override.spec.ts
@@ -30,6 +30,11 @@ describe('#crud', () => {
           type: 'string',
           enum: Field,
         },
+        disabledField: {
+          field: 'disabled_field',
+          type: 'number',
+          disabled: true,
+        },
       },
     })
     @Controller('test')
@@ -114,6 +119,14 @@ describe('#crud', () => {
         const enumParam = params.find((param) => param.name === 'enumField');
         expect(enumParam).toBeDefined();
         expect(enumParam.enum).toEqual(['one']);
+      });
+      it('should not return disabled fields in swagger', () => {
+        const params = Swagger.getParams(TestController.prototype.getMany);
+        expect(Array.isArray(params)).toBe(true);
+        expect(params.length > 0).toBe(true);
+
+        const disabledParam = params.find((param) => param.name === 'disabledField');
+        expect(disabledParam).toBeUndefined();
       });
       it('should return swagger response ok', () => {
         const response = Swagger.getResponseOk(TestController.prototype.getMany);


### PR DESCRIPTION
Parameters such as `id` might be disabled, as described in [this link](https://github.com/nestjsx/crud/wiki/Controllers#params), to allow the creation of endpoints such as `GET /me`. However, even if those parameters are disabled, the Swagger UI requires them to be informed. This PR fixes this behavior by removing the disabled parameters from Swagger UI list.

Fixes https://github.com/nestjsx/crud/issues/539.