### PR TITLE
fix(crud): typo fix getMayRouteOptions -> getManyRouteOptions

### DIFF
--- a/packages/crud/src/interfaces/routes-options.interface.ts
+++ b/packages/crud/src/interfaces/routes-options.interface.ts
@@ -3,7 +3,7 @@ import { BaseRouteName } from '../types';
 export interface RoutesOptions {
   exclude?: BaseRouteName[];
   only?: BaseRouteName[];
-  getManyBase?: GetMayRouteOptions;
+  getManyBase?: GetManyRouteOptions;
   getOneBase?: GetOneRouteOptions;
   createOneBase?: CreateOneRouteOptions;
   createManyBase?: CreateManyRouteOptions;
@@ -17,7 +17,7 @@ export interface BaseRouteOptions {
   decorators?: (PropertyDecorator | MethodDecorator)[];
 }
 
-export interface GetMayRouteOptions extends BaseRouteOptions {}
+export interface GetManyRouteOptions extends BaseRouteOptions {}
 
 export interface GetOneRouteOptions extends BaseRouteOptions {}
 


### PR DESCRIPTION
Simple typo fix. Nothing was broken because typo persisted through file. 