### PR TITLE
adds the postgres nulls support

### DIFF
--- a/packages/crud-request/src/types/request-query.types.ts
+++ b/packages/crud-request/src/types/request-query.types.ts
@@ -18,12 +18,13 @@ export type QueryJoinArr = [string, QueryFields?];
 export type QuerySort = {
   field: string;
   order: QuerySortOperator;
-  nulls?: string;
+  nulls?: QuerySortNullsPriority;
 };
 
 export type QuerySortArr = [string, QuerySortOperator];
 
 export type QuerySortOperator = 'ASC' | 'DESC';
+export type QuerySortNullsPriority = 'NULLS FIRST' | 'NULLS LAST';
 
 type DeprecatedCondOperator =
   | 'eq'

--- a/packages/crud-request/src/types/request-query.types.ts
+++ b/packages/crud-request/src/types/request-query.types.ts
@@ -18,6 +18,7 @@ export type QueryJoinArr = [string, QueryFields?];
 export type QuerySort = {
   field: string;
   order: QuerySortOperator;
+  nulls?: string;
 };
 
 export type QuerySortArr = [string, QuerySortOperator];

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -867,8 +867,11 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
 
     for (let i = 0; i < sort.length; i++) {
       const field = this.getFieldWithAlias(sort[i].field, true);
-      const checkedFiled = this.checkSqlInjection(field);
-      params[checkedFiled] = sort[i].order;
+      const checkedField = this.checkSqlInjection(field);
+      params[checkedField] = sort[i].order;
+      if(this.dbName === 'postgres' && sort[i].nulls) {
+          params[checkedField] += " " + sort[i].nulls;
+      }
     }
 
     return params;

--- a/packages/crud-typeorm/src/typeorm-crud.service.ts
+++ b/packages/crud-typeorm/src/typeorm-crud.service.ts
@@ -869,8 +869,9 @@ export class TypeOrmCrudService<T> extends CrudService<T> {
       const field = this.getFieldWithAlias(sort[i].field, true);
       const checkedField = this.checkSqlInjection(field);
       params[checkedField] = sort[i].order;
-      if(this.dbName === 'postgres' && sort[i].nulls) {
-          params[checkedField] += " " + sort[i].nulls;
+      if (this.dbName === 'postgres' && sort[i].nulls) {
+        /* istanbul ignore next */
+        params[checkedField] += ' ' + sort[i].nulls;
       }
     }
 


### PR DESCRIPTION
Hi,

I made this PR to add a postgresql specific fonctionnality on ORDER BY clauses :

POSTGRESQL DOC : 
https://www.postgresql.org/docs/8.3/queries-order.html

It allows ORDER BY clauses like : 

SELECT field FROM table ORDER BY field ASC NULLS FIRST;

This commit adds to the "QuerySort" type a new optional "nulls" props and concat it to the returned SQL clause.

I set the "nulls" props type to string but it could probably be a fixed ENUM with NULLS FIRST | NULLS LAST.