### PR TITLE
fix: Add missing dependency "pluralize"

### DIFF
--- a/packages/crud/package.json
+++ b/packages/crud/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@nestjsx/crud-request": "^5.0.0-alpha.1",
     "@nestjsx/util": "^5.0.0-alpha.1",
-    "deepmerge": "^3.2.0"
+    "deepmerge": "^3.2.0",
+    "pluralize": "^8.0.0"
   },
   "peerDependencies": {
     "class-transformer": "*",


### PR DESCRIPTION
Current version: v5.0.0-alpha.1
Build with error: `Error: Cannot find module 'pluralize'`
