### PR TITLE
fix(): webpack properly bundles optional packages

### DIFF
--- a/packages/crud/src/crud/swagger.helper.ts
+++ b/packages/crud/src/crud/swagger.helper.ts
@@ -1,16 +1,19 @@
 import { HttpStatus } from '@nestjs/common';
-import { objKeys, isString, isFunction } from '@nestjsx/util';
 import { RequestQueryBuilder } from '@nestjsx/crud-request';
-const pluralize = require('pluralize');
-
+import { isString, objKeys } from '@nestjsx/util';
+import { MergedCrudOptions, ParamsOptions } from '../interfaces';
+import { BaseRouteName } from '../types';
 import { safeRequire } from '../util';
 import { R } from './reflection.helper';
-import { ParamsOptions, MergedCrudOptions } from '../interfaces';
-import { BaseRouteName } from '../types';
+const pluralize = require('pluralize');
 
-export const swagger = safeRequire('@nestjs/swagger');
-export const swaggerConst = safeRequire('@nestjs/swagger/dist/constants');
-export const swaggerPkgJson = safeRequire('@nestjs/swagger/package.json');
+export const swagger = safeRequire('@nestjs/swagger', () => require('@nestjs/swagger'));
+export const swaggerConst = safeRequire('@nestjs/swagger/dist/constants', () =>
+  require('@nestjs/swagger/dist/constants'),
+);
+export const swaggerPkgJson = safeRequire('@nestjs/swagger/package.json', () =>
+  require('@nestjs/swagger/package.json'),
+);
 
 export class Swagger {
   static operationsMap(modelName): { [key in BaseRouteName]: string } {

--- a/packages/crud/src/crud/validation.helper.ts
+++ b/packages/crud/src/crud/validation.helper.ts
@@ -1,13 +1,12 @@
 import { ValidationPipe } from '@nestjs/common';
 import { isFalse, isNil } from '@nestjsx/util';
-
 import { CrudValidationGroups } from '../enums';
 import { CreateManyDto, CrudOptions, MergedCrudOptions } from '../interfaces';
 import { safeRequire } from '../util';
 import { ApiProperty } from './swagger.helper';
 
-const validator = safeRequire('class-validator');
-const transformer = safeRequire('class-transformer');
+const validator = safeRequire('class-validator', () => require('class-validator'));
+const transformer = safeRequire('class-transformer', () => require('class-transformer'));
 
 class BulkDto<T> implements CreateManyDto<T> {
   bulk: T[];

--- a/packages/crud/src/util.ts
+++ b/packages/crud/src/util.ts
@@ -1,6 +1,6 @@
-export function safeRequire<T = any>(path: string): T | null {
+export function safeRequire<T = any>(path: string, loader?: () => T): T | null {
   try {
-    const pack = require(path);
+    const pack = loader ? loader() : require(path);
     return pack;
   } catch (_) {
     /* istanbul ignore next */


### PR DESCRIPTION
With an optional `loader` function, webpack is now able to bundle & tie dependencies together. This wasn't working before as `require(path)` is dynamic - webpack does not recognize the custom `safeRequire` function and so it cannot properly wire up external deps.

The change is very minor: `safeRequire` accepts a second argument now and if present executes it instead of running `require(path)`. Otherwise, it will fallback to the original behavior.