### PR TITLE
Feature: add array operators

### DIFF
--- a/packages/crud-request/src/request-query.parser.ts
+++ b/packages/crud-request/src/request-query.parser.ts
@@ -270,6 +270,8 @@ export class RequestQueryParser implements ParsedRequestParams {
       '$between',
       '$inL',
       '$notinL',
+      '$contArr',
+      '$intersectsArr',
     ];
     const isEmptyValue = ['isnull', 'notnull', '$isnull', '$notnull'];
     const param = data.split(this._options.delim);

--- a/packages/crud-request/src/request-query.validator.ts
+++ b/packages/crud-request/src/request-query.validator.ts
@@ -36,6 +36,8 @@ export const deprecatedComparisonOperatorsList = [
   'isnull',
   'notnull',
   'between',
+  'contArr',
+  'intersectsArr',
 ];
 export const comparisonOperatorsList = [
   ...deprecatedComparisonOperatorsList,

--- a/packages/crud-request/src/types/request-query.types.ts
+++ b/packages/crud-request/src/types/request-query.types.ts
@@ -39,7 +39,9 @@ type DeprecatedCondOperator =
   | 'notin'
   | 'isnull'
   | 'notnull'
-  | 'between';
+  | 'between'
+  | 'contArr'
+  | 'intersectsArr';
 
 export enum CondOperator {
   EQUALS = '$eq',
@@ -65,6 +67,8 @@ export enum CondOperator {
   EXCLUDES_LOW = '$exclL',
   IN_LOW = '$inL',
   NOT_IN_LOW = '$notinL',
+  CONTAINS_ARRAY = '$contArr',
+  INTERSECTS_ARRAY = '$intersectsArr',
 }
 
 export type ComparisonOperator = DeprecatedCondOperator | keyof SFieldOperator;
@@ -98,6 +102,8 @@ export type SFieldOperator = {
   $exclL?: SFiledValues;
   $inL?: SFiledValues;
   $notinL?: SFiledValues;
+  $contArr?: Array<SPrimitivesVal>;
+  $intersectsArr?: Array<SPrimitivesVal>;
   $or?: SFieldOperator;
   $and?: never;
 };

--- a/packages/crud-request/src/types/request-query.types.ts
+++ b/packages/crud-request/src/types/request-query.types.ts
@@ -76,32 +76,34 @@ export type ComparisonOperator = DeprecatedCondOperator | keyof SFieldOperator;
 // new search
 export type SPrimitivesVal = string | number | boolean;
 
-export type SFiledValues = SPrimitivesVal | Array<SPrimitivesVal>;
+export type SFieldValues = SPrimitivesVal | Array<SPrimitivesVal>;
+// DEPRECATED: remove before next major release (or other breaking change)
+export type SFiledValues = SFieldValues;
 
 export type SFieldOperator = {
-  $eq?: SFiledValues;
-  $ne?: SFiledValues;
-  $gt?: SFiledValues;
-  $lt?: SFiledValues;
-  $gte?: SFiledValues;
-  $lte?: SFiledValues;
-  $starts?: SFiledValues;
-  $ends?: SFiledValues;
-  $cont?: SFiledValues;
-  $excl?: SFiledValues;
-  $in?: SFiledValues;
-  $notin?: SFiledValues;
-  $between?: SFiledValues;
-  $isnull?: SFiledValues;
-  $notnull?: SFiledValues;
-  $eqL?: SFiledValues;
-  $neL?: SFiledValues;
-  $startsL?: SFiledValues;
-  $endsL?: SFiledValues;
-  $contL?: SFiledValues;
-  $exclL?: SFiledValues;
-  $inL?: SFiledValues;
-  $notinL?: SFiledValues;
+  $eq?: SFieldValues;
+  $ne?: SFieldValues;
+  $gt?: SFieldValues;
+  $lt?: SFieldValues;
+  $gte?: SFieldValues;
+  $lte?: SFieldValues;
+  $starts?: SFieldValues;
+  $ends?: SFieldValues;
+  $cont?: SFieldValues;
+  $excl?: SFieldValues;
+  $in?: SFieldValues;
+  $notin?: SFieldValues;
+  $between?: SFieldValues;
+  $isnull?: SFieldValues;
+  $notnull?: SFieldValues;
+  $eqL?: SFieldValues;
+  $neL?: SFieldValues;
+  $startsL?: SFieldValues;
+  $endsL?: SFieldValues;
+  $contL?: SFieldValues;
+  $exclL?: SFieldValues;
+  $inL?: SFieldValues;
+  $notinL?: SFieldValues;
   $contArr?: Array<SPrimitivesVal>;
   $intersectsArr?: Array<SPrimitivesVal>;
   $or?: SFieldOperator;


### PR DESCRIPTION
Adds new `contArr` and `intersectsArr` query operators, with the `intersectsArr` operator generating SQL queries like:

```
select ... where tags::text[] && ARRAY[$1,$2];
```

This selects rows where the `tags` column, which is presumed to be of type `text[]`, contains at least one value that equals `$1` or `$2`. 

Fixes #687 